### PR TITLE
Add KeyMap::KMT_ANDROID_KEY and support an extra androidKey in KMT_CLICK and KMT_CLICK_TWICE

### DIFF
--- a/src/device/controller/inputconvert/inputconvertgame.cpp
+++ b/src/device/controller/inputconvert/inputconvertgame.cpp
@@ -112,9 +112,11 @@ void InputConvertGame::keyEvent(const QKeyEvent *from, const QSize &frameSize, c
         // 处理普通按键
         case KeyMap::KMT_CLICK:
             processKeyClick(node.data.click.keyNode.pos, false, node.data.click.switchMap, from);
+            processAndroidKey(node.data.click.keyNode.androidKey, from);
             return;
         case KeyMap::KMT_CLICK_TWICE:
             processKeyClick(node.data.clickTwice.keyNode.pos, true, false, from);
+            processAndroidKey(node.data.clickTwice.keyNode.androidKey, from);
             return;
         case KeyMap::KMT_CLICK_MULTI:
             processKeyClickMulti(node.data.clickMulti.keyNode.delayClickNodes, node.data.clickMulti.keyNode.delayClickNodesCount, from);

--- a/src/device/controller/inputconvert/inputconvertgame.h
+++ b/src/device/controller/inputconvert/inputconvertgame.h
@@ -28,6 +28,7 @@ protected:
     void sendTouchMoveEvent(int id, QPointF pos);
     void sendTouchUpEvent(int id, QPointF pos);
     void sendTouchEvent(int id, QPointF pos, AndroidMotioneventAction action);
+    void sendKeyEvent(AndroidKeyeventAction action, AndroidKeycode keyCode);
     QPointF calcFrameAbsolutePos(QPointF relativePos);
     QPointF calcScreenAbsolutePos(QPointF relativePos);
 
@@ -47,6 +48,9 @@ protected:
 
     // drag
     void processKeyDrag(const QPointF &startPos, QPointF endPos, const QKeyEvent *from);
+
+    // android key
+    void processAndroidKey(AndroidKeycode androidKey, const QKeyEvent *from);
 
     // mouse
     bool processMouseClick(const QMouseEvent *from);

--- a/src/device/controller/inputconvert/keymap/keymap.cpp
+++ b/src/device/controller/inputconvert/keymap/keymap.cpp
@@ -166,6 +166,7 @@ void KeyMap::loadKeyMap(const QString &json)
                 keyMapNode.data.click.keyNode.key = key.second;
                 keyMapNode.data.click.keyNode.pos = getItemPos(node, "pos");
                 keyMapNode.data.click.switchMap = getItemBool(node, "switchMap");
+                keyMapNode.data.click.keyNode.androidKey = static_cast<AndroidKeycode>(getItemDouble(node, "androidKey"));
                 m_keyMapNodes.push_back(keyMapNode);
             } break;
             case KeyMap::KMT_CLICK_TWICE: {
@@ -186,6 +187,7 @@ void KeyMap::loadKeyMap(const QString &json)
                 keyMapNode.data.click.keyNode.key = key.second;
                 keyMapNode.data.click.keyNode.pos = getItemPos(node, "pos");
                 keyMapNode.data.click.switchMap = getItemBool(node, "switchMap");
+                keyMapNode.data.click.keyNode.androidKey = static_cast<AndroidKeycode>(getItemDouble(node, "androidKey"));
                 m_keyMapNodes.push_back(keyMapNode);
             } break;
             case KeyMap::KMT_CLICK_MULTI: {

--- a/src/device/controller/inputconvert/keymap/keymap.cpp
+++ b/src/device/controller/inputconvert/keymap/keymap.cpp
@@ -282,6 +282,25 @@ void KeyMap::loadKeyMap(const QString &json)
                 m_keyMapNodes.push_back(keyMapNode);
                 break;
             }
+            case KeyMap::KMT_ANDROID_KEY: {
+                // safe check
+                if (!checkForAndroidKey(node)) {
+                    qWarning() << "json error: keyMapNodes node format error";
+                    break;
+                }
+
+                QPair<ActionType, int> key = getItemKey(node, "key");
+                if (key.first == AT_INVALID) {
+                    qWarning() << "json error: keyMapNodes node invalid key: " << node.value("key").toString();
+                    break;
+                }
+                KeyMapNode keyMapNode;
+                keyMapNode.type = type;
+                keyMapNode.data.androidKey.keyNode.type = key.first;
+                keyMapNode.data.androidKey.keyNode.key = key.second;
+                keyMapNode.data.androidKey.keyNode.androidKey = static_cast<AndroidKeycode>(getItemDouble(node, "androidKey"));
+                m_keyMapNodes.push_back(keyMapNode);
+            } break;
             default:
                 qWarning() << "json error: keyMapNodes invalid node type:" << node.value("type").toString();
                 break;
@@ -375,6 +394,10 @@ void KeyMap::makeReverseMap()
         case KMT_DRAG: {
             QMultiHash<int, KeyMapNode *> &m = node.data.drag.keyNode.type == AT_KEY ? m_rmapKey : m_rmapMouse;
             m.insert(node.data.drag.keyNode.key, &node);
+        } break;
+        case KMT_ANDROID_KEY: {
+            QMultiHash<int, KeyMapNode *> &m = node.data.androidKey.keyNode.type == AT_KEY ? m_rmapKey : m_rmapMouse;
+            m.insert(node.data.androidKey.keyNode.key, &node);
         } break;
         default:
             break;
@@ -504,6 +527,11 @@ bool KeyMap::checkForDelayClickNode(const QJsonObject &node)
 bool KeyMap::checkForClickTwice(const QJsonObject &node)
 {
     return checkItemString(node, "key") && checkItemPos(node, "pos");
+}
+
+bool KeyMap::checkForAndroidKey(const QJsonObject &node)
+{
+    return checkItemString(node, "key") && checkItemDouble(node, "androidKey");
 }
 
 bool KeyMap::checkForSteerWhell(const QJsonObject &node)

--- a/src/device/controller/inputconvert/keymap/keymap.h
+++ b/src/device/controller/inputconvert/keymap/keymap.h
@@ -9,6 +9,8 @@
 #include <QRectF>
 #include <QVector>
 
+#include "keycodes.h"
+
 #define MAX_DELAY_CLICK_NODES 50
 
 class KeyMap : public QObject
@@ -23,7 +25,8 @@ public:
         KMT_CLICK_MULTI,
         KMT_STEER_WHEEL,
         KMT_DRAG,
-        KMT_MOUSE_MOVE
+        KMT_MOUSE_MOVE,
+        KMT_ANDROID_KEY
     };
     Q_ENUM(KeyMapType)
 
@@ -50,14 +53,16 @@ public:
         double extendOffset = 0.0;                             // for steerWheel
         DelayClickNode delayClickNodes[MAX_DELAY_CLICK_NODES]; // for multi clicks
         int delayClickNodesCount = 0;
+        AndroidKeycode androidKey = AKEYCODE_UNKNOWN;          // for key press
 
         KeyNode(
             ActionType type = AT_INVALID,
             int key = Qt::Key_unknown,
             QPointF pos = QPointF(0, 0),
             QPointF extendPos = QPointF(0, 0),
-            double extendOffset = 0.0)
-            : type(type), key(key), pos(pos), extendPos(extendPos), extendOffset(extendOffset)
+            double extendOffset = 0.0,
+            AndroidKeycode androidKey = AKEYCODE_UNKNOWN)
+            : type(type), key(key), pos(pos), extendPos(extendPos), extendOffset(extendOffset), androidKey(androidKey)
         {
         }
     };
@@ -95,6 +100,10 @@ public:
                 QPointF speedRatio = { 1.0, 1.0 };
                 KeyNode smallEyes;
             } mouseMove;
+            struct
+            {
+                KeyNode keyNode;
+            } androidKey;
             DATA() {}
             ~DATA() {}
         } data;
@@ -135,6 +144,7 @@ private:
     bool checkForClickTwice(const QJsonObject &node);
     bool checkForSteerWhell(const QJsonObject &node);
     bool checkForDrag(const QJsonObject &node);
+    bool checkForAndroidKey(const QJsonObject &node);
 
     // get keymap from json object
     QString getItemString(const QJsonObject &node, const QString &name);


### PR DESCRIPTION
This maps a key to an Android key in customized key mapping mode.

Use case: PUBG Mobile supports character movement directly using WASD
keys: try it with a keyboard directly connected to an Android phone,
or when customized key mapping is turned off. This should be a more
reliable approach to achieve movement than using the steer wheel.

The current design requires users to configure Android key codes into
the keymap file, due the the fact that we can't use QMetaEnum in
keycodes.h. I don't want to have another layer of translation (such as
InputConvertNormal::convertKeyCode) because we typically want a more
direct control, and I don't want to introduce another meta-programming
approach just to support this corner use case.

Using Android key "W" to move forward in PUBG moves the character
slowly (walk). To run with "W", I would configure "W" as KMT_CLICK_TWICE
on the Auto-run icon, and the functionality to trigger an Android key "W"
is still needed in the case of driving a vehicle.

An alternative approach is to configure Shift as KMT_CLICK_TWICE on
Auto-run. This would enable the "walk" functionality which was not
possible. However this would conflict with "boost" when driving since
the key for "boost" needs to be KMT_CLICK (not TWICE).

Users should be able to configure the keymap in whichever way they want.