### PR TITLE
fix: build failed with Qt5.11 and GCC8.3.

### DIFF
--- a/src/device/decoder/decoder.h
+++ b/src/device/decoder/decoder.h
@@ -7,6 +7,8 @@ extern "C"
 #include "libavcodec/avcodec.h"
 }
 
+#include <functional>
+
 class VideoBuffer;
 class Decoder : public QObject
 {

--- a/src/device/decoder/videobuffer.h
+++ b/src/device/decoder/videobuffer.h
@@ -5,6 +5,7 @@
 #include <QWaitCondition>
 #include <QObject>
 
+#include <functional>
 #include "fpscounter.h"
 
 // forward declarations


### PR DESCRIPTION
the header ‘<functional>’ was included QDebug, if miss include functional or Debug, it would error: ‘std::function’ has not been declared.

Log: fix build failed issue.