### PR TITLE
fix:build on ubuntu22.04 Qt5.12.12 error: ‘std::function’ has not bee…

### DIFF
--- a/src/device/decoder/videobuffer.h
+++ b/src/device/decoder/videobuffer.h
@@ -4,6 +4,7 @@
 #include <QMutex>
 #include <QWaitCondition>
 #include <QObject>
+#include <QMap>
 
 #include "fpscounter.h"
 


### PR DESCRIPTION
OS: Ubuntu 22.04
Qt: 5.12.12
cmake version 3.22.1

build error:
[ 40%] Building CXX object QtScrcpy/QtScrcpyCore/CMakeFiles/QtScrcpyCore.dir/src/device/decoder/videobuffer.cpp.o
In file included from /home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.cpp:1:
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.h:38:33: error: ‘std::function’ has not been declared
   38 |     void peekRenderedFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame);
      |                                 ^~~~~~~~
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.h:38:41: error: expected ‘,’ or ‘...’ before ‘<’ token
   38 |     void peekRenderedFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame);
      |                                         ^
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.cpp:110:6: error: variable or field ‘peekRenderedFrame’ declared void
  110 | void VideoBuffer::peekRenderedFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame)
      |      ^~~~~~~~~~~
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.cpp:110:42: error: ‘function’ is not a member of ‘std’
  110 | void VideoBuffer::peekRenderedFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame)
      |                                          ^~~~~~~~
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.cpp:8:1: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
    7 | #include "libavutil/imgutils.h"
  +++ |+#include <functional>
    8 | }
/home/ian/Desktop/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/decoder/videobuffer.cpp:110:97: error: expression list treated as compound expression in functional cast [-fpermissive]


