### PR TITLE
feat: Enable install files into CMAKE_INSTALL_PREFIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,4 +222,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/adb/linux/adb" "${QSC_DEPLOY_PATH}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/scrcpy-server" "${QSC_DEPLOY_PATH}"
     )
+    install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/adb/linux/adb DESTINATION bin)
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/scrcpy-server DESTINATION bin)
 endif()


### PR DESCRIPTION
support "make install" for usually used or build package.

Log: enable install after make.