### PR TITLE
feat: add configurable drag speed and delay

### DIFF
--- a/src/device/controller/inputconvert/inputconvertgame.h
+++ b/src/device/controller/inputconvert/inputconvertgame.h
@@ -47,7 +47,7 @@ protected:
     void processKeyClickMulti(const KeyMap::DelayClickNode *nodes, const int count, const QKeyEvent *from);
 
     // drag
-    void processKeyDrag(const QPointF &startPos, QPointF endPos, const QKeyEvent *from);
+    void processKeyDrag(const QPointF &startPos, QPointF endPos, quint32 startDelay, float dragSpeed, const QKeyEvent *from);
 
     // android key
     void processAndroidKey(AndroidKeycode androidKey, const QKeyEvent *from);

--- a/src/device/controller/inputconvert/keymap/keymap.cpp
+++ b/src/device/controller/inputconvert/keymap/keymap.cpp
@@ -281,6 +281,11 @@ void KeyMap::loadKeyMap(const QString &json)
                 keyMapNode.data.drag.keyNode.key = key.second;
                 keyMapNode.data.drag.keyNode.pos = getItemPos(node, "startPos");
                 keyMapNode.data.drag.keyNode.extendPos = getItemPos(node, "endPos");
+                // Read optional drag delay parameters
+                keyMapNode.data.drag.startDelay = node.contains("startDelay") ? 
+                    static_cast<quint32>(getItemDouble(node, "startDelay")) : 0;
+                keyMapNode.data.drag.dragSpeed = node.contains("dragSpeed") ? 
+                    static_cast<float>(getItemDouble(node, "dragSpeed")) : 1.0f;
                 m_keyMapNodes.push_back(keyMapNode);
                 break;
             }

--- a/src/device/controller/inputconvert/keymap/keymap.h
+++ b/src/device/controller/inputconvert/keymap/keymap.h
@@ -93,6 +93,8 @@ public:
             struct
             {
                 KeyNode keyNode;
+                quint32 startDelay = 0;      // delay before starting drag movement
+                float dragSpeed = 1.0;       // speed of the drag (0-1, 1=fastest)
             } drag;
             struct
             {


### PR DESCRIPTION
Added startDelay and dragSpeed parameters to control drag movements:
- startDelay: one can specify a delay in MS after the first touch and before the actual drag movement
- dragSpeed range: 0-1 (1=fastest)
- At speed 1: minDelay=1ms, maxDelay=2ms
- At speed 0: minDelay=30ms, maxDelay=40ms
- Delays are linearly interpolated based on dragSpeed
- Each drag movement uses a random delay between minDelay and maxDelay

This allows users to fine-tune both the speed and responsiveness of drag movements according to their needs.

```json
    {
      "comment": "",
      "type": "KMT_DRAG",
      "startPos": {
        "x": 0.2896,
        "y": 0.68
      },
      "endPos": {
        "x": 0.8344,
        "y": 0.1363
      },
      "key": "Key_Space",
      "switchMap": false,
      "startDelay": 100, //delay for 100ms after the first touch and before the movement
      "dragSpeed": 0.95 //(0-1) to control the movement speed (1=fast, 0=slow)
    }
```