### PR TITLE
fix: when the record video folder non-existent may crush.

### DIFF
--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -50,6 +50,11 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
             fileName.replace(".", "_");
             fileName += ("." + m_params.recordFileFormat);
             QDir dir(fileDir);
+            if (!dir.exists()) {
+                if (!dir.mkpath(fileDir)) {
+                    qCritical() << QString("Failed to create the save folder: %1").arg(fileDir);
+                }
+            }
             absFilePath = dir.absoluteFilePath(fileName);
         }
         m_recorder = new Recorder(absFilePath, this);


### PR DESCRIPTION
When you accidentally delete the folder that saves the videos or the folder non-existent, may crash.

Log: when the record video folder non-existent may crush.


https://github.com/user-attachments/assets/0b60669a-31ae-4c85-b1e9-1e67c0734405

