### PR TITLE
fix: prevent camera reset when holding smallEyes key (Alt)

### DIFF
--- a/src/device/controller/inputconvert/inputconvertgame.cpp
+++ b/src/device/controller/inputconvert/inputconvertgame.cpp
@@ -734,6 +734,9 @@ void InputConvertGame::timerEvent(QTimerEvent *event)
 {
     if (m_ctrlMouseMove.timer == event->timerId()) {
         stopMouseMoveTimer();
-        mouseMoveStopTouch();
+        // Don't auto-reset view when smallEyes mode is active
+        if (!m_ctrlMouseMove.smallEyes) {
+            mouseMoveStopTouch();
+        }
     }
 }


### PR DESCRIPTION
## Problem
When using the `smallEyes` feature (holding Alt key to move camera around player), the camera would unexpectedly reset after 500ms of no mouse movement, even though the Alt key was still being held.

## Root Cause
The [timerEvent](cci:1://file:///d:/Programs/Wapo/Mobile/ScrCpy/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/controller/inputconvert/inputconvertgame.cpp:732:0-741:1) function was calling [mouseMoveStopTouch()](cci:1://file:///d:/Programs/Wapo/Mobile/ScrCpy/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/controller/inputconvert/inputconvertgame.cpp:674:0-681:1) after the 500ms timer expired, regardless of whether smallEyes mode was active.

## Solution
Added a conditional check in [timerEvent](cci:1://file:///d:/Programs/Wapo/Mobile/ScrCpy/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/controller/inputconvert/inputconvertgame.cpp:732:0-741:1) to prevent the auto-reset when `m_ctrlMouseMove.smallEyes` is active.

## Changes
- Modified [InputConvertGame::timerEvent()](cci:1://file:///d:/Programs/Wapo/Mobile/ScrCpy/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/controller/inputconvert/inputconvertgame.cpp:732:0-741:1) in [inputconvertgame.cpp](cci:7://file:///d:/Programs/Wapo/Mobile/ScrCpy/QtScrcpy/QtScrcpy/QtScrcpyCore/src/device/controller/inputconvert/inputconvertgame.cpp:0:0-0:0)
- Added 3 lines to check if smallEyes is active before stopping touch
- Minimal impact: Only affects timer-based auto-reset behavior

## Testing
- Tested with smallEyes enabled (holding Alt key)
- Camera no longer resets when pausing mouse movement
- Normal mouse move mode still works as expected (timer auto-reset still functions)
- All other keymap features remain unaffected

## Impact
- Zero breaking changes
- Preserves all existing functionality
- Only fixes the specific smallEyes timer issue