### PR TITLE
fix: re-center mouseMoveMap cursor on macOS with CGWarp + CGAssociate

### DIFF
--- a/src/device/controller/inputconvert/inputconvertgame.cpp
+++ b/src/device/controller/inputconvert/inputconvertgame.cpp
@@ -5,6 +5,10 @@
 #include <QTime>
 #include <QRandomGenerator>
 
+#ifdef Q_OS_MACOS
+#include <CoreGraphics/CoreGraphics.h>
+#endif
+
 #include "inputconvertgame.h"
 
 #define CURSOR_POS_CHECK 50
@@ -656,7 +660,20 @@ void InputConvertGame::moveCursorTo(const QMouseEvent *from, const QPoint &local
 #endif
     globalPos -= posOffset;
     //qDebug()<<"move cursor to "<<globalPos<<" offset "<<posOffset;
+#ifdef Q_OS_MACOS
+    // On macOS, QCursor::setPos() posts a synthetic mouse-moved event (CGEventPost)
+    // and does NOT re-associate the hardware mouse with the on-screen cursor, so the
+    // warp does not "stick": the next hardware delta snaps the cursor back. That makes
+    // mouseMoveMap re-centering a no-op, and the camera can no longer pan past the edge.
+    // CGWarpMouseCursorPosition performs a real warp, and
+    // CGAssociateMouseAndMouseCursorPosition(true) immediately restores the
+    // mouse<->cursor association so subsequent hardware deltas keep flowing. This
+    // mirrors the approach already used in util/mousetap/cocoamousetap.mm.
+    CGWarpMouseCursorPosition(CGPointMake(globalPos.x(), globalPos.y()));
+    CGAssociateMouseAndMouseCursorPosition(true);
+#else
     QCursor::setPos(globalPos);
+#endif
 }
 
 void InputConvertGame::mouseMoveStartTouch(const QMouseEvent *from)


### PR DESCRIPTION
Hey there! I came across QtScrcpy while researching ways to play Genshin Impact
on macOS, and I've been really impressed with it, the keymapping especially.
The one thing that kept tripping me up was the horizontal pointer drifting
off-screen during continuous panning on Mac. So I dug in and put together a
fix, tried and tested in real gameplay. Details below.

## Summary

In keymap "mapping mode" (`mouseMoveMap`), the cursor is warped back from the
edge of the video so the camera can pan continuously. **On macOS this
re-centering never takes effect**, so the camera stops rotating once the cursor
reaches the edge of the window/screen. Lowering `speedRatio` only delays the
limit; it never removes it.

Fixes barry-ran/QtScrcpy#571 ("MAC - MOUSE STOPPING ON THE BORDER OF THE SCREEN"),
and also resolves its open duplicate barry-ran/QtScrcpy#809.

This is the Qt 6-era recurrence of a bug originally reported and fixed in 2020
(barry-ran/QtScrcpy#200, since closed): that fix worked under Qt 5, but Qt 6
changed `QCursor::setPos()` on macOS to a synthetic event with no mouse/cursor
re-association, which silently broke the old re-centering again.

## Root cause

`InputConvertGame::moveCursorTo()` re-centers the cursor with
`QCursor::setPos()`. On macOS, Qt 6 implements `QCursor::setPos()` as a
*synthetic* mouse-moved event (`CGEventCreateMouseEvent` + `CGEventPost`) and
does **not** re-associate the hardware mouse with the cursor. The warp therefore
does not "stick": the next hardware movement snaps the cursor back, so
re-centering is effectively a no-op and the camera can no longer pan past the
edge.

(On a multi-monitor setup the same root cause shows up slightly differently: the
un-recentered cursor simply escapes onto the adjacent display instead of pinning
at a hard edge.)

## Fix

On macOS, replace `QCursor::setPos()` with a real warp followed by re-association:

```cpp
CGWarpMouseCursorPosition(CGPointMake(globalPos.x(), globalPos.y()));
CGAssociateMouseAndMouseCursorPosition(true);
```

This is the **same pair already used** in `util/mousetap/cocoamousetap.mm` for
cursor confinement, so it introduces no new dependency (CoreGraphics is already
linked). `CGAssociateMouseAndMouseCursorPosition(true)` keeps hardware deltas
flowing immediately after the warp.

The change is guarded by `#ifdef Q_OS_MACOS`; **Windows and Linux keep
`QCursor::setPos()` unchanged** via `#else`.

## Verification

I instrumented a debug build to log, on every re-center, the requested warp
target vs. the cursor position read back immediately after the warp:

| Build | Re-centers that actually moved the cursor to target |
|-------|------------------------------------------------------|
| before (`QCursor::setPos`) | **0 / 111** |
| after (`CGWarp` + `CGAssociate`) | **39 / 41** |

Before, the warp requested `x=-1870` but the cursor stayed at `x=-47` (no-op):
```
moveCursorTo warpGlobal=(-1870,439) cursorAfter=(-47,439)
```
After, the warp lands on target:
```
moveCursorTo warpGlobal=(-1393,450) cursorAfter=(-1393,450)
```

Tested in live gameplay (Genshin Impact) on Apple Silicon / macOS, Qt 6.5.3:
the camera now pans without limit and the cursor stays within the mirror window.

## Notes

This is my first contribution here, happy to adjust the approach, commit
message, or style to match your conventions.
