### PR TITLE
feat: add VideoToolbox hardware decoder and dual-mode decode support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(QSC_DEVICE_SOURCES
     src/device/decoder/fpscounter.cpp
     src/device/decoder/videobuffer.h
     src/device/decoder/videobuffer.cpp
+    src/device/decoder/vtdecoder.h
     src/device/filehandler/filehandler.h
     src/device/filehandler/filehandler.cpp
     src/device/recorder/recorder.h
@@ -198,6 +199,11 @@ endif()
 
 # MacOS
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    # VideoToolbox decoder (macOS, Objective-C++)
+    target_sources(${QSC_PROJECT_NAME} PRIVATE
+        src/device/decoder/vtdecoder.mm
+    )
+
     # ffmpeg
     # include
     target_include_directories(${QSC_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/ffmpeg/include)
@@ -209,6 +215,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         avcodec.58
         avutil.56
         swscale.5
+    )
+
+    # VideoToolbox + CoreMedia + CoreVideo (Apple Silicon H.264 硬解)
+    target_link_libraries(${QSC_PROJECT_NAME} PRIVATE
+        "-framework VideoToolbox"
+        "-framework CoreMedia"
+        "-framework CoreVideo"
     )
 
     # copy bundle file    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(QSC_INCLUDE_SOURCES
     include/QtScrcpyCore.h
     include/QtScrcpyCoreDef.h
     include/adbprocess.h
+    include/IDecoder.h
 )
 source_group(include FILES ${QSC_INCLUDE_SOURCES})
 

--- a/include/IDecoder.h
+++ b/include/IDecoder.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <QObject>
+#include <functional>
+
+extern "C"
+{
+#include "libavcodec/avcodec.h"
+}
+
+/// 解码器抽象接口
+/// Decoder (FFmpeg) 和 VTDecoder (VideoToolbox) 均实现此接口，
+/// 由 Device 根据 decodeMode 工厂创建具体实例。
+class IDecoder : public QObject
+{
+    Q_OBJECT
+public:
+    explicit IDecoder(QObject *parent = nullptr) : QObject(parent) {}
+    virtual ~IDecoder() = default;
+
+    /// 打开解码器，初始化资源
+    virtual bool open() = 0;
+
+    /// 关闭解码器，释放所有资源
+    virtual void close() = 0;
+
+    /// 推送一帧待解码的 AVPacket
+    virtual bool push(const AVPacket *packet) = 0;
+
+    /// 截屏：获取当前帧的 RGB32 数据
+    virtual void peekFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame) = 0;
+
+signals:
+    void updateFPS(quint32 fps);
+};

--- a/include/QtScrcpyCore.h
+++ b/include/QtScrcpyCore.h
@@ -26,6 +26,12 @@ public:
         Q_UNUSED(linesizeU);
         Q_UNUSED(linesizeV);
     }
+    // VideoToolbox Metal 路径帧回调（仅 macOS arm64）
+    virtual void onFrameMetal(void* cvPixelBuffer, int width, int height) {
+        Q_UNUSED(cvPixelBuffer);
+        Q_UNUSED(width);
+        Q_UNUSED(height);
+    }
     virtual void updateFPS(quint32 fps) { Q_UNUSED(fps); }
     virtual void grabCursor(bool grab) {Q_UNUSED(grab);}
 

--- a/include/QtScrcpyCoreDef.h
+++ b/include/QtScrcpyCoreDef.h
@@ -1,6 +1,12 @@
 #pragma once
 #include <QString>
 
+/// 解码模式枚举
+enum DecodeMode {
+    MODE_FFMPEG = 0,
+    MODE_VT_METAL = 1
+};
+
 namespace qsc {
 
 struct DeviceParams {

--- a/include/QtScrcpyCoreDef.h
+++ b/include/QtScrcpyCoreDef.h
@@ -39,6 +39,7 @@ struct DeviceParams {
     bool display = true;              // 是否显示画面（或者仅仅后台录制）
     bool renderExpiredFrames = false; // 是否渲染延迟视频帧
     QString gameScript = "";          // 游戏映射脚本
+    int decodeMode = 0;               // 0=FFmpeg OpenGL (默认), 1=VideoToolbox Metal (Apple Silicon)
 };
     
 }

--- a/src/device/decoder/decoder.cpp
+++ b/src/device/decoder/decoder.cpp
@@ -99,18 +99,27 @@ bool Decoder::pushVT(const AVPacket *packet)
         return false;
     }
 
-    // 互斥更新最新帧
+    // 互斥更新最新帧 — 所有权转移
     {
         QMutexLocker lock(&m_pixelBufferMutex);
-        if (m_lastPixelBuffer) CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
-        CVPixelBufferRetain(pb);
+        if (m_lastPixelBuffer) {
+            CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+            m_lastPixelBuffer = nullptr;
+        }
         m_lastPixelBuffer = pb;
         m_lastFrameWidth = w;
         m_lastFrameHeight = h;
     }
-    CVPixelBufferRelease(pb);
 
-    emit newFrame();
+    // 非重复发出 newFrame 信号：仅当主线程空闲时才发
+    // VT 硬件解码极快，不跳过帧，保持 GOP 连续避免马赛克
+    if (m_frameInFlight.loadAcquire() == 0) {
+        m_frameInFlight.storeRelease(1);
+        emit newFrame();
+    }
+    // 当 m_frameInFlight > 0 时，主线程还在渲染上一帧。
+    // 不发信号—主线程完成渲染后会检查 m_lastPixelBuffer，
+    // pushVT 下一次调用会覆盖 m_lastPixelBuffer（在互斥锁内释放旧帧）。
     return true;
 #else
     Q_UNUSED(packet);
@@ -151,8 +160,13 @@ bool Decoder::push(const AVPacket *packet)
 void Decoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
 {
 #ifdef Q_OS_MACOS
-    if (m_decodeMode == MODE_VT_METAL && m_lastPixelBuffer) {
+    if (m_decodeMode == MODE_VT_METAL) {
+        QMutexLocker lock(&m_pixelBufferMutex);
         CVPixelBufferRef pb = (CVPixelBufferRef)m_lastPixelBuffer;
+        if (!pb) return;
+        CVPixelBufferRetain(pb);
+        lock.unlock();
+
         CVPixelBufferLockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
 
         int w = (int)CVPixelBufferGetWidth(pb);
@@ -182,6 +196,7 @@ void Decoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
             }
         }
         CVPixelBufferUnlockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
+        CVPixelBufferRelease(pb);
 
         onFrame(w, h, rgb);
         delete[] rgb;
@@ -203,17 +218,32 @@ void Decoder::pushFrame()
 void Decoder::onNewFrame()
 {
     if (m_decodeMode == MODE_VT_METAL) {
-        if (!onMetalFrame) return;
+        if (!onMetalFrame) {
+            m_frameInFlight.storeRelease(0);
+            return;
+        }
 
+        // 取走 pixel buffer 所有权
         QMutexLocker lock(&m_pixelBufferMutex);
         void *pb = m_lastPixelBuffer;
-        if (!pb) return;
-        CVPixelBufferRetain((CVPixelBufferRef)pb);
+        m_lastPixelBuffer = nullptr;  // 所有权转移
         int w = m_lastFrameWidth, h = m_lastFrameHeight;
         lock.unlock();
 
+        if (!pb) {
+            m_frameInFlight.storeRelease(0);
+            return;
+        }
+
+        // 渲染接管生命周期：renderFrame 内部 Retain 给 GPU handler
         onMetalFrame(pb, w, h);
+
+        // 释放 VT callback 持有的那一次 Retain
+        // （如果 renderFrame Retain 了，GPU handler 会最终释放）
         CVPixelBufferRelease((CVPixelBufferRef)pb);
+
+        // 背压清除：允许 pushVT 推送下一帧
+        m_frameInFlight.storeRelease(0);
         return;
     }
 

--- a/src/device/decoder/decoder.cpp
+++ b/src/device/decoder/decoder.cpp
@@ -4,7 +4,7 @@
 #include "decoder.h"
 #include "videobuffer.h"
 
-Decoder::Decoder(std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> onFrame, QObject *parent)
+Decoder::Decoder(std::function<void(int, int, uint8_t*, uint8_t*, uint8_t*, int, int, int)> onFrame, QObject *parent)
     : IDecoder(parent)
     , m_vb(new VideoBuffer())
     , m_onFrame(onFrame)
@@ -14,19 +14,21 @@ Decoder::Decoder(std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,i
     connect(m_vb, &VideoBuffer::updateFPS, this, &Decoder::updateFPS);
 }
 
-Decoder::~Decoder()
-{
+Decoder::~Decoder() {
     m_vb->deInit();
     delete m_vb;
 }
 
 bool Decoder::open()
 {
+    // codec
     const AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_H264);
     if (!codec) {
         qCritical("H.264 decoder not found");
         return false;
     }
+
+    // codec context
     m_codecCtx = avcodec_alloc_context3(codec);
     if (!m_codecCtx) {
         qCritical("Could not allocate decoder context");
@@ -42,64 +44,111 @@ bool Decoder::open()
 
 void Decoder::close()
 {
-    if (m_vb) m_vb->interrupt();
-
-    if (m_codecCtx) {
-        if (m_isCodecCtxOpen) avcodec_close(m_codecCtx);
-        avcodec_free_context(&m_codecCtx);
+    if (m_vb) {
+        m_vb->interrupt();
     }
+
+    if (!m_codecCtx) {
+        return;
+    }
+    if (m_isCodecCtxOpen) {
+        avcodec_close(m_codecCtx);
+    }
+    avcodec_free_context(&m_codecCtx);
 }
 
 bool Decoder::push(const AVPacket *packet)
 {
-    if (!m_codecCtx || !m_vb) return false;
-
-    AVFrame *decodingFrame = m_vb->decodingFrame();
-#ifdef QTSCRCPY_LAVF_HAS_NEW_ENCODING_DECODING_API
-    int ret = avcodec_send_packet(m_codecCtx, packet);
-    if (ret < 0) {
-        char err[256] = {0};
-        av_strerror(ret, err, 255);
-        qCritical("send_packet: %s", err);
+    if (!m_codecCtx || !m_vb) {
         return false;
     }
-    if (decodingFrame && avcodec_receive_frame(m_codecCtx, decodingFrame) == 0) {
+    AVFrame *decodingFrame = m_vb->decodingFrame();
+#ifdef QTSCRCPY_LAVF_HAS_NEW_ENCODING_DECODING_API
+    int ret = -1;
+    if ((ret = avcodec_send_packet(m_codecCtx, packet)) < 0) {
+        char errorbuf[255] = { 0 };
+        av_strerror(ret, errorbuf, 254);
+        qCritical("Could not send video packet: %s", errorbuf);
+        return false;
+    }
+    if (decodingFrame) {
+        ret = avcodec_receive_frame(m_codecCtx, decodingFrame);
+    }
+    if (!ret) {
+        // a frame was received
         pushFrame();
+
+        //emit getOneFrame(yuvDecoderFrame->data[0], yuvDecoderFrame->data[1], yuvDecoderFrame->data[2],
+        //        yuvDecoderFrame->linesize[0], yuvDecoderFrame->linesize[1], yuvDecoderFrame->linesize[2]);
+
+        /*
+        // m_conver转换yuv为rgb是使用cpu转的，占用cpu太高，改用opengl渲染yuv
+        // QImage的copy也非常占用内存，此方案不考虑
+        if (!m_conver.isInit()) {
+            qDebug() << "decoder frame format" << decodingFrame->format;
+            m_conver.setSrcFrameInfo(codecCtx->width, codecCtx->height, AV_PIX_FMT_YUV420P);
+            m_conver.setDstFrameInfo(codecCtx->width, codecCtx->height, AV_PIX_FMT_RGB32);
+            m_conver.init();
+        }
+        if (!outBuffer) {
+            outBuffer=new quint8[avpicture_get_size(AV_PIX_FMT_RGB32, codecCtx->width, codecCtx->height)];
+            avpicture_fill((AVPicture *)rgbDecoderFrame, outBuffer, AV_PIX_FMT_RGB32, codecCtx->width, codecCtx->height);
+        }
+        m_conver.convert(decodingFrame, rgbDecoderFrame);
+        //QImage tmpImg((uchar *)outBuffer, codecCtx->width, codecCtx->height, QImage::Format_RGB32);
+        //QImage image = tmpImg.copy();
+        //emit getOneImage(image);
+        */
     } else if (ret != AVERROR(EAGAIN)) {
-        qCritical("receive_frame: %d", ret);
+        qCritical("Could not receive video frame: %d", ret);
         return false;
     }
 #else
-    int got = 0;
-    int len = decodingFrame ? avcodec_decode_video2(m_codecCtx, decodingFrame, &got, packet) : -1;
-    if (len < 0) { qCritical("decode: %d", len); return false; }
-    if (got) pushFrame();
+    int gotPicture = 0;
+    int len = -1;
+    if (decodingFrame) {
+        len = avcodec_decode_video2(m_codecCtx, decodingFrame, &gotPicture, packet);
+    }
+    if (len < 0) {
+        qCritical("Could not decode video packet: %d", len);
+        return false;
+    }
+    if (gotPicture) {
+        pushFrame();
+    }
 #endif
     return true;
 }
 
-void Decoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
+void Decoder::peekFrame(std::function<void (int, int, uint8_t *)> onFrame)
 {
-    if (m_vb) m_vb->peekRenderedFrame(onFrame);
+    if (!m_vb) {
+        return;
+    }
+    m_vb->peekRenderedFrame(onFrame);
 }
 
 void Decoder::pushFrame()
 {
-    if (!m_vb) return;
-    bool skipped = true;
-    m_vb->offerDecodedFrame(skipped);
-    if (skipped) return;
+    if (!m_vb) {
+        return;
+    }
+    bool previousFrameSkipped = true;
+    m_vb->offerDecodedFrame(previousFrameSkipped);
+    if (previousFrameSkipped) {
+        // the previous newFrame will consume this frame
+        return;
+    }
     emit newFrame();
 }
 
-void Decoder::onNewFrame()
-{
-    if (m_onFrame) {
-        m_vb->lock();
-        const AVFrame *frame = m_vb->consumeRenderedFrame();
-        m_onFrame(frame->width, frame->height,
-                  frame->data[0], frame->data[1], frame->data[2],
-                  frame->linesize[0], frame->linesize[1], frame->linesize[2]);
-        m_vb->unLock();
+void Decoder::onNewFrame() {
+    if (!m_onFrame) {
+        return;
     }
+
+    m_vb->lock();
+    const AVFrame *frame = m_vb->consumeRenderedFrame();
+    m_onFrame(frame->width, frame->height, frame->data[0], frame->data[1], frame->data[2], frame->linesize[0], frame->linesize[1], frame->linesize[2]);
+    m_vb->unLock();
 }

--- a/src/device/decoder/decoder.cpp
+++ b/src/device/decoder/decoder.cpp
@@ -3,14 +3,9 @@
 #include "compat.h"
 #include "decoder.h"
 #include "videobuffer.h"
-#include "vtdecoder.h"
-
-#ifdef Q_OS_MACOS
-#include <CoreVideo/CoreVideo.h>
-#endif
 
 Decoder::Decoder(std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> onFrame, QObject *parent)
-    : QObject(parent)
+    : IDecoder(parent)
     , m_vb(new VideoBuffer())
     , m_onFrame(onFrame)
 {
@@ -23,30 +18,10 @@ Decoder::~Decoder()
 {
     m_vb->deInit();
     delete m_vb;
-#ifdef Q_OS_MACOS
-    if (m_lastPixelBuffer) {
-        CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
-    }
-#endif
 }
 
-bool Decoder::open(int decodeMode)
+bool Decoder::open()
 {
-#ifdef Q_OS_MACOS
-    if (decodeMode == MODE_VT_METAL) {
-        m_vtDecoder = new VTDecoder(this);
-        if (m_vtDecoder->open()) {
-            m_decodeMode = MODE_VT_METAL;
-            connect(m_vtDecoder, &VTDecoder::updateFPS, this, &Decoder::updateFPS);
-            qInfo("Decoder: VideoToolbox + Metal mode");
-            return true;
-        }
-        qWarning("Decoder: VTDecoder open failed, fallback to FFmpeg");
-        delete m_vtDecoder;
-        m_vtDecoder = Q_NULLPTR;
-    }
-#endif
-
     const AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_H264);
     if (!codec) {
         qCritical("H.264 decoder not found");
@@ -62,7 +37,6 @@ bool Decoder::open(int decodeMode)
         return false;
     }
     m_isCodecCtxOpen = true;
-    m_decodeMode = MODE_FFMPEG;
     return true;
 }
 
@@ -70,67 +44,14 @@ void Decoder::close()
 {
     if (m_vb) m_vb->interrupt();
 
-    if (m_vtDecoder) {
-        m_vtDecoder->close();
-    }
-#ifdef Q_OS_MACOS
-    if (m_lastPixelBuffer) {
-        CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
-        m_lastPixelBuffer = nullptr;
-    }
-#endif
-    m_lastFrameWidth = m_lastFrameHeight = 0;
-
     if (m_codecCtx) {
         if (m_isCodecCtxOpen) avcodec_close(m_codecCtx);
         avcodec_free_context(&m_codecCtx);
     }
 }
 
-bool Decoder::pushVT(const AVPacket *packet)
-{
-#ifdef Q_OS_MACOS
-    if (!m_vtDecoder || !packet) return false;
-
-    CVPixelBufferRef pb = nullptr;
-    int w = 0, h = 0;
-
-    if (!m_vtDecoder->decode(packet->data, packet->size, packet->pts, pb, w, h) || !pb) {
-        return false;
-    }
-
-    // 互斥更新最新帧 — 所有权转移
-    {
-        QMutexLocker lock(&m_pixelBufferMutex);
-        if (m_lastPixelBuffer) {
-            CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
-            m_lastPixelBuffer = nullptr;
-        }
-        m_lastPixelBuffer = pb;
-        m_lastFrameWidth = w;
-        m_lastFrameHeight = h;
-    }
-
-    // 非重复发出 newFrame 信号：仅当主线程空闲时才发
-    // VT 硬件解码极快，不跳过帧，保持 GOP 连续避免马赛克
-    if (m_frameInFlight.loadAcquire() == 0) {
-        m_frameInFlight.storeRelease(1);
-        emit newFrame();
-    }
-    // 当 m_frameInFlight > 0 时，主线程还在渲染上一帧。
-    // 不发信号—主线程完成渲染后会检查 m_lastPixelBuffer，
-    // pushVT 下一次调用会覆盖 m_lastPixelBuffer（在互斥锁内释放旧帧）。
-    return true;
-#else
-    Q_UNUSED(packet);
-    return false;
-#endif
-}
-
 bool Decoder::push(const AVPacket *packet)
 {
-    if (m_decodeMode == MODE_VT_METAL) return pushVT(packet);
-
     if (!m_codecCtx || !m_vb) return false;
 
     AVFrame *decodingFrame = m_vb->decodingFrame();
@@ -159,50 +80,6 @@ bool Decoder::push(const AVPacket *packet)
 
 void Decoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
 {
-#ifdef Q_OS_MACOS
-    if (m_decodeMode == MODE_VT_METAL) {
-        QMutexLocker lock(&m_pixelBufferMutex);
-        CVPixelBufferRef pb = (CVPixelBufferRef)m_lastPixelBuffer;
-        if (!pb) return;
-        CVPixelBufferRetain(pb);
-        lock.unlock();
-
-        CVPixelBufferLockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
-
-        int w = (int)CVPixelBufferGetWidth(pb);
-        int h = (int)CVPixelBufferGetHeight(pb);
-
-        uint8_t *y  = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 0);
-        uint8_t *uv = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 1);
-        size_t ys = CVPixelBufferGetBytesPerRowOfPlane(pb, 0);
-        size_t uvs = CVPixelBufferGetBytesPerRowOfPlane(pb, 1);
-
-        uint8_t *rgb = new uint8_t[w * h * 4];
-        for (int row = 0; row < h; row++) {
-            for (int col = 0; col < w; col++) {
-                int yy  = y[row * ys + col];
-                int uu  = uv[(row>>1) * uvs + (col & ~1)];
-                int vv  = uv[(row>>1) * uvs + (col & ~1) + 1];
-
-                float yf = (yy - 16) / 219.0f;
-                float uf = (uu - 128) / 224.0f;
-                float vf = (vv - 128) / 224.0f;
-
-                int idx = (row * w + col) * 4;
-                rgb[idx+0] = (uint8_t)qBound(0, (int)(255*(yf + 1.7927f*vf)), 255);
-                rgb[idx+1] = (uint8_t)qBound(0, (int)(255*(yf - 0.2132f*uf - 0.5329f*vf)), 255);
-                rgb[idx+2] = (uint8_t)qBound(0, (int)(255*(yf + 2.1124f*uf)), 255);
-                rgb[idx+3] = 255;
-            }
-        }
-        CVPixelBufferUnlockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
-        CVPixelBufferRelease(pb);
-
-        onFrame(w, h, rgb);
-        delete[] rgb;
-        return;
-    }
-#endif
     if (m_vb) m_vb->peekRenderedFrame(onFrame);
 }
 
@@ -217,37 +94,6 @@ void Decoder::pushFrame()
 
 void Decoder::onNewFrame()
 {
-    if (m_decodeMode == MODE_VT_METAL) {
-        if (!onMetalFrame) {
-            m_frameInFlight.storeRelease(0);
-            return;
-        }
-
-        // 取走 pixel buffer 所有权
-        QMutexLocker lock(&m_pixelBufferMutex);
-        void *pb = m_lastPixelBuffer;
-        m_lastPixelBuffer = nullptr;  // 所有权转移
-        int w = m_lastFrameWidth, h = m_lastFrameHeight;
-        lock.unlock();
-
-        if (!pb) {
-            m_frameInFlight.storeRelease(0);
-            return;
-        }
-
-        // 渲染接管生命周期：renderFrame 内部 Retain 给 GPU handler
-        onMetalFrame(pb, w, h);
-
-        // 释放 VT callback 持有的那一次 Retain
-        // （如果 renderFrame Retain 了，GPU handler 会最终释放）
-        CVPixelBufferRelease((CVPixelBufferRef)pb);
-
-        // 背压清除：允许 pushVT 推送下一帧
-        m_frameInFlight.storeRelease(0);
-        return;
-    }
-
-    // FFmpeg 路径
     if (m_onFrame) {
         m_vb->lock();
         const AVFrame *frame = m_vb->consumeRenderedFrame();

--- a/src/device/decoder/decoder.cpp
+++ b/src/device/decoder/decoder.cpp
@@ -3,8 +3,13 @@
 #include "compat.h"
 #include "decoder.h"
 #include "videobuffer.h"
+#include "vtdecoder.h"
 
-Decoder::Decoder(std::function<void(int, int, uint8_t*, uint8_t*, uint8_t*, int, int, int)> onFrame, QObject *parent)
+#ifdef Q_OS_MACOS
+#include <CoreVideo/CoreVideo.h>
+#endif
+
+Decoder::Decoder(std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> onFrame, QObject *parent)
     : QObject(parent)
     , m_vb(new VideoBuffer())
     , m_onFrame(onFrame)
@@ -14,21 +19,39 @@ Decoder::Decoder(std::function<void(int, int, uint8_t*, uint8_t*, uint8_t*, int,
     connect(m_vb, &VideoBuffer::updateFPS, this, &Decoder::updateFPS);
 }
 
-Decoder::~Decoder() {
+Decoder::~Decoder()
+{
     m_vb->deInit();
     delete m_vb;
+#ifdef Q_OS_MACOS
+    if (m_lastPixelBuffer) {
+        CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+    }
+#endif
 }
 
-bool Decoder::open()
+bool Decoder::open(int decodeMode)
 {
-    // codec
+#ifdef Q_OS_MACOS
+    if (decodeMode == MODE_VT_METAL) {
+        m_vtDecoder = new VTDecoder(this);
+        if (m_vtDecoder->open()) {
+            m_decodeMode = MODE_VT_METAL;
+            connect(m_vtDecoder, &VTDecoder::updateFPS, this, &Decoder::updateFPS);
+            qInfo("Decoder: VideoToolbox + Metal mode");
+            return true;
+        }
+        qWarning("Decoder: VTDecoder open failed, fallback to FFmpeg");
+        delete m_vtDecoder;
+        m_vtDecoder = Q_NULLPTR;
+    }
+#endif
+
     const AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_H264);
     if (!codec) {
         qCritical("H.264 decoder not found");
         return false;
     }
-
-    // codec context
     m_codecCtx = avcodec_alloc_context3(codec);
     if (!m_codecCtx) {
         qCritical("Could not allocate decoder context");
@@ -39,116 +62,168 @@ bool Decoder::open()
         return false;
     }
     m_isCodecCtxOpen = true;
+    m_decodeMode = MODE_FFMPEG;
     return true;
 }
 
 void Decoder::close()
 {
-    if (m_vb) {
-        m_vb->interrupt();
+    if (m_vb) m_vb->interrupt();
+
+    if (m_vtDecoder) {
+        m_vtDecoder->close();
+    }
+#ifdef Q_OS_MACOS
+    if (m_lastPixelBuffer) {
+        CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+        m_lastPixelBuffer = nullptr;
+    }
+#endif
+    m_lastFrameWidth = m_lastFrameHeight = 0;
+
+    if (m_codecCtx) {
+        if (m_isCodecCtxOpen) avcodec_close(m_codecCtx);
+        avcodec_free_context(&m_codecCtx);
+    }
+}
+
+bool Decoder::pushVT(const AVPacket *packet)
+{
+#ifdef Q_OS_MACOS
+    if (!m_vtDecoder || !packet) return false;
+
+    CVPixelBufferRef pb = nullptr;
+    int w = 0, h = 0;
+
+    if (!m_vtDecoder->decode(packet->data, packet->size, packet->pts, pb, w, h) || !pb) {
+        return false;
     }
 
-    if (!m_codecCtx) {
-        return;
+    // 互斥更新最新帧
+    {
+        QMutexLocker lock(&m_pixelBufferMutex);
+        if (m_lastPixelBuffer) CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+        CVPixelBufferRetain(pb);
+        m_lastPixelBuffer = pb;
+        m_lastFrameWidth = w;
+        m_lastFrameHeight = h;
     }
-    if (m_isCodecCtxOpen) {
-        avcodec_close(m_codecCtx);
-    }
-    avcodec_free_context(&m_codecCtx);
+    CVPixelBufferRelease(pb);
+
+    emit newFrame();
+    return true;
+#else
+    Q_UNUSED(packet);
+    return false;
+#endif
 }
 
 bool Decoder::push(const AVPacket *packet)
 {
-    if (!m_codecCtx || !m_vb) {
-        return false;
-    }
+    if (m_decodeMode == MODE_VT_METAL) return pushVT(packet);
+
+    if (!m_codecCtx || !m_vb) return false;
+
     AVFrame *decodingFrame = m_vb->decodingFrame();
 #ifdef QTSCRCPY_LAVF_HAS_NEW_ENCODING_DECODING_API
-    int ret = -1;
-    if ((ret = avcodec_send_packet(m_codecCtx, packet)) < 0) {
-        char errorbuf[255] = { 0 };
-        av_strerror(ret, errorbuf, 254);
-        qCritical("Could not send video packet: %s", errorbuf);
+    int ret = avcodec_send_packet(m_codecCtx, packet);
+    if (ret < 0) {
+        char err[256] = {0};
+        av_strerror(ret, err, 255);
+        qCritical("send_packet: %s", err);
         return false;
     }
-    if (decodingFrame) {
-        ret = avcodec_receive_frame(m_codecCtx, decodingFrame);
-    }
-    if (!ret) {
-        // a frame was received
+    if (decodingFrame && avcodec_receive_frame(m_codecCtx, decodingFrame) == 0) {
         pushFrame();
-
-        //emit getOneFrame(yuvDecoderFrame->data[0], yuvDecoderFrame->data[1], yuvDecoderFrame->data[2],
-        //        yuvDecoderFrame->linesize[0], yuvDecoderFrame->linesize[1], yuvDecoderFrame->linesize[2]);
-
-        /*
-        // m_conver转换yuv为rgb是使用cpu转的，占用cpu太高，改用opengl渲染yuv
-        // QImage的copy也非常占用内存，此方案不考虑
-        if (!m_conver.isInit()) {
-            qDebug() << "decoder frame format" << decodingFrame->format;
-            m_conver.setSrcFrameInfo(codecCtx->width, codecCtx->height, AV_PIX_FMT_YUV420P);
-            m_conver.setDstFrameInfo(codecCtx->width, codecCtx->height, AV_PIX_FMT_RGB32);
-            m_conver.init();
-        }
-        if (!outBuffer) {
-            outBuffer=new quint8[avpicture_get_size(AV_PIX_FMT_RGB32, codecCtx->width, codecCtx->height)];
-            avpicture_fill((AVPicture *)rgbDecoderFrame, outBuffer, AV_PIX_FMT_RGB32, codecCtx->width, codecCtx->height);
-        }
-        m_conver.convert(decodingFrame, rgbDecoderFrame);
-        //QImage tmpImg((uchar *)outBuffer, codecCtx->width, codecCtx->height, QImage::Format_RGB32);
-        //QImage image = tmpImg.copy();
-        //emit getOneImage(image);
-        */
     } else if (ret != AVERROR(EAGAIN)) {
-        qCritical("Could not receive video frame: %d", ret);
+        qCritical("receive_frame: %d", ret);
         return false;
     }
 #else
-    int gotPicture = 0;
-    int len = -1;
-    if (decodingFrame) {
-        len = avcodec_decode_video2(m_codecCtx, decodingFrame, &gotPicture, packet);
-    }
-    if (len < 0) {
-        qCritical("Could not decode video packet: %d", len);
-        return false;
-    }
-    if (gotPicture) {
-        pushFrame();
-    }
+    int got = 0;
+    int len = decodingFrame ? avcodec_decode_video2(m_codecCtx, decodingFrame, &got, packet) : -1;
+    if (len < 0) { qCritical("decode: %d", len); return false; }
+    if (got) pushFrame();
 #endif
     return true;
 }
 
-void Decoder::peekFrame(std::function<void (int, int, uint8_t *)> onFrame)
+void Decoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
 {
-    if (!m_vb) {
+#ifdef Q_OS_MACOS
+    if (m_decodeMode == MODE_VT_METAL && m_lastPixelBuffer) {
+        CVPixelBufferRef pb = (CVPixelBufferRef)m_lastPixelBuffer;
+        CVPixelBufferLockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
+
+        int w = (int)CVPixelBufferGetWidth(pb);
+        int h = (int)CVPixelBufferGetHeight(pb);
+
+        uint8_t *y  = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 0);
+        uint8_t *uv = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 1);
+        size_t ys = CVPixelBufferGetBytesPerRowOfPlane(pb, 0);
+        size_t uvs = CVPixelBufferGetBytesPerRowOfPlane(pb, 1);
+
+        uint8_t *rgb = new uint8_t[w * h * 4];
+        for (int row = 0; row < h; row++) {
+            for (int col = 0; col < w; col++) {
+                int yy  = y[row * ys + col];
+                int uu  = uv[(row>>1) * uvs + (col & ~1)];
+                int vv  = uv[(row>>1) * uvs + (col & ~1) + 1];
+
+                float yf = (yy - 16) / 219.0f;
+                float uf = (uu - 128) / 224.0f;
+                float vf = (vv - 128) / 224.0f;
+
+                int idx = (row * w + col) * 4;
+                rgb[idx+0] = (uint8_t)qBound(0, (int)(255*(yf + 1.7927f*vf)), 255);
+                rgb[idx+1] = (uint8_t)qBound(0, (int)(255*(yf - 0.2132f*uf - 0.5329f*vf)), 255);
+                rgb[idx+2] = (uint8_t)qBound(0, (int)(255*(yf + 2.1124f*uf)), 255);
+                rgb[idx+3] = 255;
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
+
+        onFrame(w, h, rgb);
+        delete[] rgb;
         return;
     }
-    m_vb->peekRenderedFrame(onFrame);
+#endif
+    if (m_vb) m_vb->peekRenderedFrame(onFrame);
 }
 
 void Decoder::pushFrame()
 {
-    if (!m_vb) {
-        return;
-    }
-    bool previousFrameSkipped = true;
-    m_vb->offerDecodedFrame(previousFrameSkipped);
-    if (previousFrameSkipped) {
-        // the previous newFrame will consume this frame
-        return;
-    }
+    if (!m_vb) return;
+    bool skipped = true;
+    m_vb->offerDecodedFrame(skipped);
+    if (skipped) return;
     emit newFrame();
 }
 
-void Decoder::onNewFrame() {
-    if (!m_onFrame) {
+void Decoder::onNewFrame()
+{
+    if (m_decodeMode == MODE_VT_METAL) {
+        if (!onMetalFrame) return;
+
+        QMutexLocker lock(&m_pixelBufferMutex);
+        void *pb = m_lastPixelBuffer;
+        if (!pb) return;
+        CVPixelBufferRetain((CVPixelBufferRef)pb);
+        int w = m_lastFrameWidth, h = m_lastFrameHeight;
+        lock.unlock();
+
+        onMetalFrame(pb, w, h);
+        CVPixelBufferRelease((CVPixelBufferRef)pb);
         return;
     }
 
-    m_vb->lock();
-    const AVFrame *frame = m_vb->consumeRenderedFrame();
-    m_onFrame(frame->width, frame->height, frame->data[0], frame->data[1], frame->data[2], frame->linesize[0], frame->linesize[1], frame->linesize[2]);
-    m_vb->unLock();
+    // FFmpeg 路径
+    if (m_onFrame) {
+        m_vb->lock();
+        const AVFrame *frame = m_vb->consumeRenderedFrame();
+        m_onFrame(frame->width, frame->height,
+                  frame->data[0], frame->data[1], frame->data[2],
+                  frame->linesize[0], frame->linesize[1], frame->linesize[2]);
+        m_vb->unLock();
+    }
 }

--- a/src/device/decoder/decoder.h
+++ b/src/device/decoder/decoder.h
@@ -1,18 +1,17 @@
 #ifndef DECODER_H
 #define DECODER_H
 #include <QObject>
-#include <functional>
 
 extern "C"
 {
 #include "libavcodec/avcodec.h"
 }
 
+#include <functional>
+
 #include "IDecoder.h"
 
 class VideoBuffer;
-
-/// FFmpeg 软件解码器，实现 IDecoder 接口
 class Decoder : public IDecoder
 {
     Q_OBJECT
@@ -34,11 +33,11 @@ signals:
 private:
     void pushFrame();
 
-    // FFmpeg 软解
+private:
     VideoBuffer *m_vb = Q_NULLPTR;
     AVCodecContext *m_codecCtx = Q_NULLPTR;
     bool m_isCodecCtxOpen = false;
-    std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> m_onFrame = Q_NULLPTR;
+    std::function<void(int, int, uint8_t*, uint8_t*, uint8_t*, int, int, int)> m_onFrame = Q_NULLPTR;
 };
 
 #endif // DECODER_H

--- a/src/device/decoder/decoder.h
+++ b/src/device/decoder/decoder.h
@@ -2,6 +2,7 @@
 #define DECODER_H
 #include <QObject>
 #include <QMutex>
+#include <QAtomicInt>
 
 extern "C"
 {
@@ -61,6 +62,7 @@ private:
     void *m_lastPixelBuffer = nullptr;
     int m_lastFrameWidth = 0;
     int m_lastFrameHeight = 0;
+    QAtomicInt m_frameInFlight{0};  // 背压：主线程渲染中的帧数
 };
 
 #endif // DECODER_H

--- a/src/device/decoder/decoder.h
+++ b/src/device/decoder/decoder.h
@@ -1,43 +1,29 @@
 #ifndef DECODER_H
 #define DECODER_H
 #include <QObject>
-#include <QMutex>
-#include <QAtomicInt>
+#include <functional>
 
 extern "C"
 {
 #include "libavcodec/avcodec.h"
 }
 
-#include <functional>
+#include "IDecoder.h"
 
 class VideoBuffer;
-class VTDecoder;
 
-enum DecodeMode {
-    MODE_FFMPEG = 0,
-    MODE_VT_METAL = 1
-};
-
-class Decoder : public QObject
+/// FFmpeg 软件解码器，实现 IDecoder 接口
+class Decoder : public IDecoder
 {
     Q_OBJECT
 public:
     Decoder(std::function<void(int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV)> onFrame, QObject *parent = Q_NULLPTR);
     virtual ~Decoder();
 
-    bool open(int decodeMode = MODE_FFMPEG);
-    void close();
-    bool push(const AVPacket *packet);
-    void peekFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame);
-
-    // Metal 渲染回调（主线程执行，CVPixelBufferRef 已 Retain）
-    std::function<void(void* cvPixelBuffer, int width, int height)> onMetalFrame = nullptr;
-
-    DecodeMode decodeMode() const { return m_decodeMode; }
-
-signals:
-    void updateFPS(quint32 fps);
+    bool open() override;
+    void close() override;
+    bool push(const AVPacket *packet) override;
+    void peekFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame) override;
 
 private slots:
     void onNewFrame();
@@ -47,22 +33,12 @@ signals:
 
 private:
     void pushFrame();
-    bool pushVT(const AVPacket *packet);
 
     // FFmpeg 软解
     VideoBuffer *m_vb = Q_NULLPTR;
     AVCodecContext *m_codecCtx = Q_NULLPTR;
     bool m_isCodecCtxOpen = false;
     std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> m_onFrame = Q_NULLPTR;
-
-    // Metal 硬解
-    VTDecoder *m_vtDecoder = Q_NULLPTR;
-    DecodeMode m_decodeMode = MODE_FFMPEG;
-    QMutex m_pixelBufferMutex;
-    void *m_lastPixelBuffer = nullptr;
-    int m_lastFrameWidth = 0;
-    int m_lastFrameHeight = 0;
-    QAtomicInt m_frameInFlight{0};  // 背压：主线程渲染中的帧数
 };
 
 #endif // DECODER_H

--- a/src/device/decoder/decoder.h
+++ b/src/device/decoder/decoder.h
@@ -1,6 +1,7 @@
 #ifndef DECODER_H
 #define DECODER_H
 #include <QObject>
+#include <QMutex>
 
 extern "C"
 {
@@ -10,6 +11,13 @@ extern "C"
 #include <functional>
 
 class VideoBuffer;
+class VTDecoder;
+
+enum DecodeMode {
+    MODE_FFMPEG = 0,
+    MODE_VT_METAL = 1
+};
+
 class Decoder : public QObject
 {
     Q_OBJECT
@@ -17,10 +25,15 @@ public:
     Decoder(std::function<void(int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV)> onFrame, QObject *parent = Q_NULLPTR);
     virtual ~Decoder();
 
-    bool open();
+    bool open(int decodeMode = MODE_FFMPEG);
     void close();
     bool push(const AVPacket *packet);
     void peekFrame(std::function<void(int width, int height, uint8_t* dataRGB32)> onFrame);
+
+    // Metal 渲染回调（主线程执行，CVPixelBufferRef 已 Retain）
+    std::function<void(void* cvPixelBuffer, int width, int height)> onMetalFrame = nullptr;
+
+    DecodeMode decodeMode() const { return m_decodeMode; }
 
 signals:
     void updateFPS(quint32 fps);
@@ -33,12 +46,21 @@ signals:
 
 private:
     void pushFrame();
+    bool pushVT(const AVPacket *packet);
 
-private:
+    // FFmpeg 软解
     VideoBuffer *m_vb = Q_NULLPTR;
     AVCodecContext *m_codecCtx = Q_NULLPTR;
     bool m_isCodecCtxOpen = false;
-    std::function<void(int, int, uint8_t*, uint8_t*, uint8_t*, int, int, int)> m_onFrame = Q_NULLPTR;
+    std::function<void(int,int,uint8_t*,uint8_t*,uint8_t*,int,int,int)> m_onFrame = Q_NULLPTR;
+
+    // Metal 硬解
+    VTDecoder *m_vtDecoder = Q_NULLPTR;
+    DecodeMode m_decodeMode = MODE_FFMPEG;
+    QMutex m_pixelBufferMutex;
+    void *m_lastPixelBuffer = nullptr;
+    int m_lastFrameWidth = 0;
+    int m_lastFrameHeight = 0;
 };
 
 #endif // DECODER_H

--- a/src/device/decoder/vtdecoder.h
+++ b/src/device/decoder/vtdecoder.h
@@ -2,11 +2,15 @@
 #define VTDECODER_H
 
 #include <QObject>
+#include <QMutex>
+#include <QAtomicInt>
+#include <functional>
 
-// 前向声明 CVPixelBufferRef（在 .mm 中 include CoreVideo）
-typedef struct __CVBuffer *CVPixelBufferRef;
+#include "IDecoder.h"
 
-class VTDecoder : public QObject
+/// VideoToolbox 硬件解码器，实现 IDecoder 接口
+/// 仅 macOS arm64 可用，由 Device 根据 decodeMode 工厂创建
+class VTDecoder : public IDecoder
 {
     Q_OBJECT
 public:
@@ -16,19 +20,25 @@ public:
     // 运行时检测：仅在 macOS arm64 返回 true
     static bool isAvailable();
 
-    // 初始化解码器（首次 decode 时懒初始化 VTDecompressionSession）
-    bool open();
-    void close();
+    // IDecoder 接口
+    bool open() override;
+    void close() override;
+    bool push(const AVPacket *packet) override;
+    void peekFrame(std::function<void(int,int,uint8_t*)> onFrame) override;
 
-    // 解码一帧 H.264 数据
-    // data: H.264 NAL 单元数据（首次调用包含 AVCDecoderConfigurationRecord 前缀）
+    // Metal 渲染回调（主线程执行，CVPixelBufferRef 已 Retain）
+    // 由 Device 在创建后设置
+    std::function<void(void* cvPixelBuffer, int width, int height)> onFrame = nullptr;
+
+    // 解码一帧 H.264 Annex B 数据（内部方法，由 push 调用，在 .mm 中实现）
+    // data: H.264 NAL 单元数据
     // size: 数据大小
     // pts: 毫秒时间戳
     // outPixelBuffer: 输出 CVPixelBufferRef（NV12, Metal 兼容, IOSurface 支持）— 调用方负责 CVPixelBufferRelease
     // outWidth/outHeight: 输出帧尺寸
     // 返回 true 表示成功解码
     bool decode(const unsigned char *data, int size, qint64 pts,
-                CVPixelBufferRef &outPixelBuffer, int &outWidth, int &outHeight);
+                void *&outPixelBuffer, int &outWidth, int &outHeight);
 
     int currentWidth() const { return m_currentWidth; }
     int currentHeight() const { return m_currentHeight; }
@@ -36,14 +46,24 @@ public:
     // 内部实现（在 .mm 中定义，供 VT 回调等静态函数使用）
     struct Impl;
 
+private slots:
+    void onNewFrame();
+
 signals:
-    void updateFPS(quint32 fps);
+    void newFrame();
 
 private:
     Impl *d = nullptr;
 
     int m_currentWidth = 0;
     int m_currentHeight = 0;
+
+    // 背压：pixel buffer 互斥 + 主线程帧数控制
+    QMutex m_pixelBufferMutex;
+    void *m_lastPixelBuffer = nullptr;
+    int m_lastFrameWidth = 0;
+    int m_lastFrameHeight = 0;
+    QAtomicInt m_frameInFlight{0};
 };
 
 #endif // VTDECODER_H

--- a/src/device/decoder/vtdecoder.h
+++ b/src/device/decoder/vtdecoder.h
@@ -1,0 +1,49 @@
+#ifndef VTDECODER_H
+#define VTDECODER_H
+
+#include <QObject>
+
+// 前向声明 CVPixelBufferRef（在 .mm 中 include CoreVideo）
+typedef struct __CVBuffer *CVPixelBufferRef;
+
+class VTDecoder : public QObject
+{
+    Q_OBJECT
+public:
+    explicit VTDecoder(QObject *parent = nullptr);
+    virtual ~VTDecoder();
+
+    // 运行时检测：仅在 macOS arm64 返回 true
+    static bool isAvailable();
+
+    // 初始化解码器（首次 decode 时懒初始化 VTDecompressionSession）
+    bool open();
+    void close();
+
+    // 解码一帧 H.264 数据
+    // data: H.264 NAL 单元数据（首次调用包含 AVCDecoderConfigurationRecord 前缀）
+    // size: 数据大小
+    // pts: 毫秒时间戳
+    // outPixelBuffer: 输出 CVPixelBufferRef（NV12, Metal 兼容, IOSurface 支持）— 调用方负责 CVPixelBufferRelease
+    // outWidth/outHeight: 输出帧尺寸
+    // 返回 true 表示成功解码
+    bool decode(const unsigned char *data, int size, qint64 pts,
+                CVPixelBufferRef &outPixelBuffer, int &outWidth, int &outHeight);
+
+    int currentWidth() const { return m_currentWidth; }
+    int currentHeight() const { return m_currentHeight; }
+
+    // 内部实现（在 .mm 中定义，供 VT 回调等静态函数使用）
+    struct Impl;
+
+signals:
+    void updateFPS(quint32 fps);
+
+private:
+    Impl *d = nullptr;
+
+    int m_currentWidth = 0;
+    int m_currentHeight = 0;
+};
+
+#endif // VTDECODER_H

--- a/src/device/decoder/vtdecoder.mm
+++ b/src/device/decoder/vtdecoder.mm
@@ -1,0 +1,349 @@
+#include "vtdecoder.h"
+
+#ifdef Q_OS_MACOS
+
+#include <QDebug>
+#include <QElapsedTimer>
+#include <vector>
+
+#import <VideoToolbox/VideoToolbox.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include <dispatch/dispatch.h>
+
+#define MAX_NALS 16
+
+struct VTDecoder::Impl
+{
+    VTDecompressionSessionRef session = nullptr;
+    CMVideoFormatDescriptionRef formatDesc = nullptr;
+
+    int lastWidth = 0;
+    int lastHeight = 0;
+
+    dispatch_semaphore_t semaphore = nullptr;
+
+    CVPixelBufferRef outputPixelBuffer = nullptr;
+    OSStatus decodeStatus = noErr;
+
+    quint32 renderedFrames = 0;
+    QElapsedTimer fpsTimer;
+    bool sessionCreated = false;
+
+    // 缓存 SPS/PPS 字节用于分辨率变化检测
+    std::vector<uint8_t> cachedSPS;
+    std::vector<uint8_t> cachedPPS;
+};
+
+static void vtDecoderCallback(void *decompressionOutputRefCon,
+                              void *sourceFrameRefCon,
+                              OSStatus status, VTDecodeInfoFlags infoFlags,
+                              CVImageBufferRef imageBuffer,
+                              CMTime, CMTime)
+{
+    Q_UNUSED(sourceFrameRefCon);
+    Q_UNUSED(infoFlags);
+
+    auto *impl = static_cast<VTDecoder::Impl *>(decompressionOutputRefCon);
+    impl->outputPixelBuffer = nullptr;
+
+    if (status == noErr && imageBuffer) {
+        CVPixelBufferRetain(imageBuffer);
+        impl->outputPixelBuffer = imageBuffer;
+    }
+    impl->decodeStatus = status;
+    dispatch_semaphore_signal(impl->semaphore);
+}
+
+static int startCodeLen(const uint8_t *p, const uint8_t *end)
+{
+    if (end - p >= 4 && p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] == 1) return 4;
+    if (end - p >= 3 && p[0] == 0 && p[1] == 0 && p[2] == 1) return 3;
+    return 0;
+}
+
+static uint8_t* annexbToAVCC(const uint8_t *data, int size,
+                              int &outAvccSize,
+                              const uint8_t *&spsData, int &spsLen,
+                              const uint8_t *&ppsData, int &ppsLen)
+{
+    spsData = ppsData = nullptr;
+    spsLen = ppsLen = 0;
+    outAvccSize = 0;
+
+    struct { const uint8_t *start; int scLen; int nalSize; int type; } nals[MAX_NALS];
+    int nalCount = 0;
+
+    const uint8_t *p = data, *end = data + size;
+    while (p < end && nalCount < MAX_NALS) {
+        int sc = startCodeLen(p, end);
+        if (sc == 0) { p++; continue; }
+
+        const uint8_t *nalStart = p;
+        const uint8_t *nalData = p + sc;
+        const uint8_t *next = nalData;
+        while (next < end && startCodeLen(next, end) == 0) next++;
+
+        int totalSize = (int)(next - nalStart);
+        int dataSize  = (int)(next - nalData);
+        int type = nalData[0] & 0x1F;
+
+        nals[nalCount++] = {nalStart, sc, totalSize, type};
+
+        if (type == 7 && !spsData) { spsData = nalData; spsLen = dataSize; }
+        if (type == 8 && !ppsData) { ppsData = nalData; ppsLen = dataSize; }
+
+        p = next;
+    }
+
+    if (nalCount == 0) return nullptr;
+
+    for (int i = 0; i < nalCount; i++) {
+        outAvccSize += 4 + (nals[i].nalSize - nals[i].scLen);
+    }
+
+    uint8_t *avcc = (uint8_t *)malloc(outAvccSize);
+    if (!avcc) return nullptr;
+
+    uint8_t *dst = avcc;
+    for (int i = 0; i < nalCount; i++) {
+        int len = nals[i].nalSize - nals[i].scLen;
+        dst[0] = (uint8_t)(len >> 24); dst[1] = (uint8_t)(len >> 16);
+        dst[2] = (uint8_t)(len >> 8);  dst[3] = (uint8_t)len;
+        dst += 4;
+        memcpy(dst, nals[i].start + nals[i].scLen, len);
+        dst += len;
+    }
+    return avcc;
+}
+
+static bool createFormatDesc(const uint8_t *sps, int slen,
+                             const uint8_t *pps, int plen,
+                             CMVideoFormatDescriptionRef &outDesc)
+{
+    const uint8_t *ptrs[2] = { sps, pps };
+    size_t sizes[2] = { (size_t)slen, (size_t)plen };
+    return CMVideoFormatDescriptionCreateFromH264ParameterSets(
+        kCFAllocatorDefault, 2, ptrs, sizes, 4, &outDesc) == noErr;
+}
+
+static bool createVTSession(CMVideoFormatDescriptionRef fd, VTDecoder::Impl *impl)
+{
+    CFMutableDictionaryRef dstAttrs = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    int pf = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+    CFNumberRef pfNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &pf);
+    CFDictionarySetValue(dstAttrs, kCVPixelBufferPixelFormatTypeKey, pfNum);
+    CFRelease(pfNum);
+    CFDictionarySetValue(dstAttrs, kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
+    CFDictionarySetValue(dstAttrs, kCVPixelBufferIOSurfacePropertiesKey, (CFDictionaryRef)@{});
+
+    VTDecompressionOutputCallbackRecord cb;
+    cb.decompressionOutputCallback = vtDecoderCallback;
+    cb.decompressionOutputRefCon = impl;
+
+    OSStatus st = VTDecompressionSessionCreate(kCFAllocatorDefault, fd,
+        nullptr, dstAttrs, &cb, &impl->session);
+    CFRelease(dstAttrs);
+
+    return st == noErr;
+}
+
+static bool doDecode(VTDecoder::Impl *d, CMBlockBufferRef bb,
+                     CMVideoFormatDescriptionRef fd, qint64 pts,
+                     CVPixelBufferRef &outPB, int &outW, int &outH)
+{
+    CMSampleTimingInfo ti;
+    ti.duration = kCMTimeInvalid;
+    ti.presentationTimeStamp = CMTimeMake(pts, 1000000);
+    ti.decodeTimeStamp = kCMTimeInvalid;
+
+    size_t bs = CMBlockBufferGetDataLength(bb);
+    size_t ss = bs;
+
+    CMSampleBufferRef sb = nullptr;
+    if (CMSampleBufferCreateReady(kCFAllocatorDefault, bb, fd, 1, 1, &ti, 1, &ss, &sb) != noErr)
+        return false;
+
+    OSStatus st = VTDecompressionSessionDecodeFrame(d->session, sb, 0, nullptr, nullptr);
+    CFRelease(sb);
+
+    if (st != noErr) {
+        if (st == -12909) return false;
+        if (st == kVTInvalidSessionErr) {
+            qWarning("VTDecoder: invalid session");
+        }
+        return false;
+    }
+
+    if (dispatch_semaphore_wait(d->semaphore,
+            dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC)) != 0) {
+        qWarning("VTDecoder: decode timeout");
+        return false;
+    }
+
+    if (d->decodeStatus != noErr || !d->outputPixelBuffer) return false;
+
+    outPB = d->outputPixelBuffer;
+    outW = (int)CVPixelBufferGetWidth(outPB);
+    outH = (int)CVPixelBufferGetHeight(outPB);
+    d->outputPixelBuffer = nullptr;
+    return true;
+}
+
+// ═══════════════════ Public API ═══════════════════
+
+VTDecoder::VTDecoder(QObject *parent) : QObject(parent), d(new Impl)
+{
+    d->fpsTimer.start();
+}
+
+VTDecoder::~VTDecoder() { close(); delete d; }
+
+bool VTDecoder::isAvailable()
+{
+#ifdef __arm64__
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool VTDecoder::open() { return true; }
+
+void VTDecoder::close()
+{
+    if (d->session) { VTDecompressionSessionInvalidate(d->session); CFRelease(d->session); d->session = nullptr; }
+    if (d->formatDesc) { CFRelease(d->formatDesc); d->formatDesc = nullptr; }
+    if (d->semaphore) { dispatch_release(d->semaphore); d->semaphore = nullptr; }
+    if (d->outputPixelBuffer) { CVPixelBufferRelease(d->outputPixelBuffer); d->outputPixelBuffer = nullptr; }
+    d->cachedSPS.clear();
+    d->cachedPPS.clear();
+    d->sessionCreated = false;
+    d->lastWidth = d->lastHeight = 0;
+    d->renderedFrames = 0;
+}
+
+bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
+                       CVPixelBufferRef &outPixelBuffer, int &outWidth, int &outHeight)
+{
+    if (!data || size <= 0) return false;
+    outPixelBuffer = nullptr;
+
+    // —— Annex B → AVCC + 提取 SPS/PPS ——
+    const uint8_t *spsData = nullptr, *ppsData = nullptr;
+    int spsSize = 0, ppsSize = 0, avccSize = 0;
+
+    uint8_t *avccData = annexbToAVCC(data, size, avccSize, spsData, spsSize, ppsData, ppsSize);
+    if (!avccData) return false;
+
+    // —— 检测 SPS/PPS 是否变化 ——
+    bool spsChanged = false;
+    if (spsData && spsSize > 0) {
+        if (spsSize != (int)d->cachedSPS.size() ||
+            memcmp(spsData, d->cachedSPS.data(), spsSize) != 0) {
+            spsChanged = true;
+            d->cachedSPS.assign(spsData, spsData + spsSize);
+            if (ppsData && ppsSize > 0) {
+                d->cachedPPS.assign(ppsData, ppsData + ppsSize);
+            }
+        }
+    }
+
+    // —— 懒初始化 / 分辨率重建 ——
+    if (!d->sessionCreated || spsChanged) {
+        if (!spsData || !ppsData) {
+            free(avccData); return false;
+        }
+
+        // 创建新 formatDesc（可能包含新分辨率）
+        CMVideoFormatDescriptionRef newFD = nullptr;
+        if (!createFormatDesc(spsData, spsSize, ppsData, ppsSize, newFD)) {
+            free(avccData); return false;
+        }
+
+        CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions(newFD);
+        int newW = dims.width, newH = dims.height;
+
+        if (!d->sessionCreated) {
+            // 首次初始化
+            d->formatDesc = newFD;
+            d->lastWidth = newW; d->lastHeight = newH;
+            m_currentWidth = newW; m_currentHeight = newH;
+
+            if (!createVTSession(d->formatDesc, d)) {
+                CFRelease(newFD); free(avccData); return false;
+            }
+            d->semaphore = dispatch_semaphore_create(0);
+            d->sessionCreated = true;
+            qInfo("VTDecoder: session created %dx%d", newW, newH);
+        } else if (newW != d->lastWidth || newH != d->lastHeight) {
+            // 分辨率变化
+            qInfo("VTDecoder: resolution change %dx%d → %dx%d",
+                  d->lastWidth, d->lastHeight, newW, newH);
+
+            if (d->session) {
+                VTDecompressionSessionInvalidate(d->session);
+                CFRelease(d->session); d->session = nullptr;
+            }
+            if (d->formatDesc) {
+                CFRelease(d->formatDesc);
+            }
+            d->formatDesc = newFD;
+            d->lastWidth = newW; d->lastHeight = newH;
+            m_currentWidth = newW; m_currentHeight = newH;
+
+            if (!createVTSession(d->formatDesc, d)) {
+                CFRelease(newFD); free(avccData); return false;
+            }
+        } else {
+            // SPS 变了但分辨率不变（如 profile 变化），仅更新 formatDesc 引用
+            if (d->formatDesc) CFRelease(d->formatDesc);
+            d->formatDesc = newFD;
+        }
+    }
+
+    if (!d->sessionCreated) {
+        free(avccData); return false;
+    }
+
+    // —— 解码 ——
+    CMBlockBufferRef bb = nullptr;
+    if (CMBlockBufferCreateWithMemoryBlock(kCFAllocatorDefault, avccData, avccSize,
+            kCFAllocatorMalloc, nullptr, 0, avccSize, 0, &bb) != kCMBlockBufferNoErr) {
+        free(avccData); return false;
+    }
+
+    CVPixelBufferRef pb = nullptr;
+    int w = 0, h = 0;
+    bool ok = doDecode(d, bb, d->formatDesc, pts, pb, w, h);
+    CFRelease(bb);
+
+    if (!ok) return false;
+
+    outPixelBuffer = pb;
+    outWidth = w;
+    outHeight = h;
+
+    d->renderedFrames++;
+    if (d->fpsTimer.elapsed() >= 1000) {
+        quint32 fps = d->renderedFrames;
+        d->renderedFrames = 0;
+        d->fpsTimer.restart();
+        emit updateFPS(fps);
+    }
+
+    return true;
+}
+
+#else
+VTDecoder::VTDecoder(QObject *parent) : QObject(parent), d(nullptr) {}
+VTDecoder::~VTDecoder() {}
+bool VTDecoder::isAvailable() { return false; }
+bool VTDecoder::open() { return false; }
+void VTDecoder::close() {}
+bool VTDecoder::decode(const unsigned char *, int, qint64, CVPixelBufferRef &o, int &w, int &h) { o = nullptr; return false; }
+#endif

--- a/src/device/decoder/vtdecoder.mm
+++ b/src/device/decoder/vtdecoder.mm
@@ -196,16 +196,13 @@ static bool doDecode(VTDecoder::Impl *d, CMBlockBufferRef bb,
         // 超时：再试一次非阻塞 wait 捕获刚触发的回调
         if (dispatch_semaphore_wait(d->semaphore, DISPATCH_TIME_NOW) == 0) {
             // 回调在我们返回前完成（慢但成功）
-            // 继续下面的 outputPixelBuffer 检查逻辑
         } else {
-            // 确认超时 — 回调从未触发
-            // 注意：回调可能稍后触发，vtDecoderCallback 会清理残留 buffer
             qWarning("VTDecoder: decode timeout (no callback in 500ms)");
             return false;
         }
     }
 
-    // 关键：在错误路径之前消费输出
+    // 在错误路径之前消费输出
     if (d->decodeStatus != noErr || !d->outputPixelBuffer) {
         if (d->outputPixelBuffer) {
             CVPixelBufferRelease(d->outputPixelBuffer);
@@ -223,9 +220,12 @@ static bool doDecode(VTDecoder::Impl *d, CMBlockBufferRef bb,
 
 // ═══════════════════ Public API ═══════════════════
 
-VTDecoder::VTDecoder(QObject *parent) : QObject(parent), d(new Impl)
+VTDecoder::VTDecoder(QObject *parent)
+    : IDecoder(parent)
+    , d(new Impl)
 {
     d->fpsTimer.start();
+    connect(this, &VTDecoder::newFrame, this, &VTDecoder::onNewFrame, Qt::QueuedConnection);
 }
 
 VTDecoder::~VTDecoder() { close(); delete d; }
@@ -247,10 +247,13 @@ void VTDecoder::close()
     if (d->session) { VTDecompressionSessionInvalidate(d->session); CFRelease(d->session); d->session = nullptr; }
     if (d->formatDesc) { CFRelease(d->formatDesc); d->formatDesc = nullptr; }
 
-    // dispatch_semaphore 的 release 必须在 VT session 失效后短暂延迟，
-    // 确保任何仍在执行的 callback 已完成 signal。
-    // VTDecompressionSessionInvalidate 是同步的，所以此处的 signal 安全。
-    if (d->semaphore) { dispatch_release(d->semaphore); d->semaphore = nullptr; }
+    // Invalidate 之后 VT 不再触发 callback，向信号量发信号唤醒可能在
+    // decode() 中等待的 Demuxer 线程，消除 500ms 超时延迟。
+    if (d->semaphore) {
+        dispatch_semaphore_signal(d->semaphore);
+        dispatch_release(d->semaphore);
+        d->semaphore = nullptr;
+    }
 
     if (d->outputPixelBuffer) { CVPixelBufferRelease(d->outputPixelBuffer); d->outputPixelBuffer = nullptr; }
     d->cachedSPS.clear();
@@ -258,10 +261,124 @@ void VTDecoder::close()
     d->sessionCreated = false;
     d->lastWidth = d->lastHeight = 0;
     d->renderedFrames = 0;
+
+    // 清理背压残留
+    QMutexLocker lock(&m_pixelBufferMutex);
+    if (m_lastPixelBuffer) {
+        CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+        m_lastPixelBuffer = nullptr;
+    }
+    m_lastFrameWidth = m_lastFrameHeight = 0;
+}
+
+bool VTDecoder::push(const AVPacket *packet)
+{
+    if (!packet || !packet->data || packet->size <= 0) return false;
+
+    void *pb = nullptr;
+    int w = 0, h = 0;
+
+    if (!decode(packet->data, packet->size, packet->pts, pb, w, h) || !pb) {
+        return false;
+    }
+
+    // 互斥更新最新帧 — 所有权转移
+    {
+        QMutexLocker lock(&m_pixelBufferMutex);
+        if (m_lastPixelBuffer) {
+            CVPixelBufferRelease((CVPixelBufferRef)m_lastPixelBuffer);
+            m_lastPixelBuffer = nullptr;
+        }
+        m_lastPixelBuffer = pb;
+        m_lastFrameWidth = w;
+        m_lastFrameHeight = h;
+    }
+
+    // 背压：仅主线程空闲时才发信号，否则保留最新帧。
+    // 解码线程持续用最新帧覆盖 m_lastPixelBuffer（旧帧释放），
+    // 主线程完成渲染后将 m_frameInFlight 重置为 0，下一个 push 再 emit。
+    // 这是"仅最新帧"策略 — 避免排队积压，保持低延迟。
+    if (m_frameInFlight.loadAcquire() == 0) {
+        m_frameInFlight.storeRelease(1);
+        emit newFrame();
+    }
+    return true;
+}
+
+void VTDecoder::peekFrame(std::function<void(int,int,uint8_t*)> onFrame)
+{
+    QMutexLocker lock(&m_pixelBufferMutex);
+    CVPixelBufferRef pb = (CVPixelBufferRef)m_lastPixelBuffer;
+    if (!pb) return;
+    CVPixelBufferRetain(pb);
+    lock.unlock();
+
+    CVPixelBufferLockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
+
+    int w = (int)CVPixelBufferGetWidth(pb);
+    int h = (int)CVPixelBufferGetHeight(pb);
+
+    uint8_t *y  = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 0);
+    uint8_t *uv = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pb, 1);
+    size_t ys = CVPixelBufferGetBytesPerRowOfPlane(pb, 0);
+    size_t uvs = CVPixelBufferGetBytesPerRowOfPlane(pb, 1);
+
+    uint8_t *rgb = new uint8_t[w * h * 4];
+    for (int row = 0; row < h; row++) {
+        for (int col = 0; col < w; col++) {
+            int yy  = y[row * ys + col];
+            int uu  = uv[(row>>1) * uvs + (col & ~1)];
+            int vv  = uv[(row>>1) * uvs + (col & ~1) + 1];
+
+            float yf = (yy - 16) / 219.0f;
+            float uf = (uu - 128) / 224.0f;
+            float vf = (vv - 128) / 224.0f;
+
+            int idx = (row * w + col) * 4;
+            rgb[idx+0] = (uint8_t)qBound(0, (int)(255*(yf + 1.7927f*vf)), 255);
+            rgb[idx+1] = (uint8_t)qBound(0, (int)(255*(yf - 0.2132f*uf - 0.5329f*vf)), 255);
+            rgb[idx+2] = (uint8_t)qBound(0, (int)(255*(yf + 2.1124f*uf)), 255);
+            rgb[idx+3] = 255;
+        }
+    }
+    CVPixelBufferUnlockBaseAddress(pb, kCVPixelBufferLock_ReadOnly);
+    CVPixelBufferRelease(pb);
+
+    onFrame(w, h, rgb);
+    delete[] rgb;
+}
+
+void VTDecoder::onNewFrame()
+{
+    if (!onFrame) {
+        m_frameInFlight.storeRelease(0);
+        return;
+    }
+
+    // 取走 pixel buffer 所有权
+    QMutexLocker lock(&m_pixelBufferMutex);
+    void *pb = m_lastPixelBuffer;
+    m_lastPixelBuffer = nullptr;  // 所有权转移
+    int w = m_lastFrameWidth, h = m_lastFrameHeight;
+    lock.unlock();
+
+    if (!pb) {
+        m_frameInFlight.storeRelease(0);
+        return;
+    }
+
+    // 渲染接管生命周期
+    onFrame(pb, w, h);
+
+    // 释放 VT callback 持有的那一次 Retain
+    CVPixelBufferRelease((CVPixelBufferRef)pb);
+
+    // 背压清除：允许 push 推送下一帧
+    m_frameInFlight.storeRelease(0);
 }
 
 bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
-                       CVPixelBufferRef &outPixelBuffer, int &outWidth, int &outHeight)
+                       void *&outPixelBuffer, int &outWidth, int &outHeight)
 {
     if (!data || size <= 0) return false;
     outPixelBuffer = nullptr;
@@ -292,7 +409,6 @@ bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
             free(avccData); return false;
         }
 
-        // 创建新 formatDesc（可能包含新分辨率）
         CMVideoFormatDescriptionRef newFD = nullptr;
         if (!createFormatDesc(spsData, spsSize, ppsData, ppsSize, newFD)) {
             free(avccData); return false;
@@ -302,7 +418,6 @@ bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
         int newW = dims.width, newH = dims.height;
 
         if (!d->sessionCreated) {
-            // 首次初始化
             d->formatDesc = newFD;
             d->lastWidth = newW; d->lastHeight = newH;
             m_currentWidth = newW; m_currentHeight = newH;
@@ -314,7 +429,6 @@ bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
             d->sessionCreated = true;
             qInfo("VTDecoder: session created %dx%d", newW, newH);
         } else if (newW != d->lastWidth || newH != d->lastHeight) {
-            // 分辨率变化
             qInfo("VTDecoder: resolution change %dx%d → %dx%d",
                   d->lastWidth, d->lastHeight, newW, newH);
 
@@ -333,9 +447,22 @@ bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
                 CFRelease(newFD); free(avccData); return false;
             }
         } else {
-            // SPS 变了但分辨率不变（如 profile 变化），仅更新 formatDesc 引用
-            if (d->formatDesc) CFRelease(d->formatDesc);
+            // SPS 变化但分辨率不变（例如 profile/level/VUI 参数变化）
+            // 仍需重建 VT 会话以确保解码参数匹配
+            qInfo("VTDecoder: SPS changed (same resolution %dx%d), recreating session",
+                  newW, newH);
+            if (d->session) {
+                VTDecompressionSessionInvalidate(d->session);
+                CFRelease(d->session); d->session = nullptr;
+            }
+            if (d->formatDesc) {
+                CFRelease(d->formatDesc);
+            }
             d->formatDesc = newFD;
+
+            if (!createVTSession(d->formatDesc, d)) {
+                CFRelease(newFD); free(avccData); return false;
+            }
         }
     }
 
@@ -373,10 +500,14 @@ bool VTDecoder::decode(const unsigned char *data, int size, qint64 pts,
 }
 
 #else
-VTDecoder::VTDecoder(QObject *parent) : QObject(parent), d(nullptr) {}
+// 非 macOS 平台的桩实现
+VTDecoder::VTDecoder(QObject *parent) : IDecoder(parent), d(nullptr) {}
 VTDecoder::~VTDecoder() {}
 bool VTDecoder::isAvailable() { return false; }
 bool VTDecoder::open() { return false; }
 void VTDecoder::close() {}
-bool VTDecoder::decode(const unsigned char *, int, qint64, CVPixelBufferRef &o, int &w, int &h) { o = nullptr; return false; }
+bool VTDecoder::push(const AVPacket *) { return false; }
+void VTDecoder::peekFrame(std::function<void(int,int,uint8_t*)>) {}
+bool VTDecoder::decode(const unsigned char *, int, qint64, void *&o, int &w, int &h) { o = nullptr; return false; }
+void VTDecoder::onNewFrame() {}
 #endif

--- a/src/device/decoder/vtdecoder.mm
+++ b/src/device/decoder/vtdecoder.mm
@@ -46,7 +46,12 @@ static void vtDecoderCallback(void *decompressionOutputRefCon,
     Q_UNUSED(infoFlags);
 
     auto *impl = static_cast<VTDecoder::Impl *>(decompressionOutputRefCon);
-    impl->outputPixelBuffer = nullptr;
+
+    // 关键：先清理上一个未被消费的 outputPixelBuffer（可能由之前超时导致）
+    if (impl->outputPixelBuffer) {
+        CVPixelBufferRelease(impl->outputPixelBuffer);
+        impl->outputPixelBuffer = nullptr;
+    }
 
     if (status == noErr && imageBuffer) {
         CVPixelBufferRetain(imageBuffer);
@@ -172,20 +177,42 @@ static bool doDecode(VTDecoder::Impl *d, CMBlockBufferRef bb,
     CFRelease(sb);
 
     if (st != noErr) {
-        if (st == -12909) return false;
+        if (st == -12909) {
+            // bad data — 清理可能被回调设置的 outputPixelBuffer
+            if (d->outputPixelBuffer) {
+                CVPixelBufferRelease(d->outputPixelBuffer);
+                d->outputPixelBuffer = nullptr;
+            }
+        }
         if (st == kVTInvalidSessionErr) {
             qWarning("VTDecoder: invalid session");
         }
         return false;
     }
 
+    // 等待异步回调完成，500ms 超时
     if (dispatch_semaphore_wait(d->semaphore,
             dispatch_time(DISPATCH_TIME_NOW, 500 * NSEC_PER_MSEC)) != 0) {
-        qWarning("VTDecoder: decode timeout");
-        return false;
+        // 超时：再试一次非阻塞 wait 捕获刚触发的回调
+        if (dispatch_semaphore_wait(d->semaphore, DISPATCH_TIME_NOW) == 0) {
+            // 回调在我们返回前完成（慢但成功）
+            // 继续下面的 outputPixelBuffer 检查逻辑
+        } else {
+            // 确认超时 — 回调从未触发
+            // 注意：回调可能稍后触发，vtDecoderCallback 会清理残留 buffer
+            qWarning("VTDecoder: decode timeout (no callback in 500ms)");
+            return false;
+        }
     }
 
-    if (d->decodeStatus != noErr || !d->outputPixelBuffer) return false;
+    // 关键：在错误路径之前消费输出
+    if (d->decodeStatus != noErr || !d->outputPixelBuffer) {
+        if (d->outputPixelBuffer) {
+            CVPixelBufferRelease(d->outputPixelBuffer);
+            d->outputPixelBuffer = nullptr;
+        }
+        return false;
+    }
 
     outPB = d->outputPixelBuffer;
     outW = (int)CVPixelBufferGetWidth(outPB);
@@ -216,9 +243,15 @@ bool VTDecoder::open() { return true; }
 
 void VTDecoder::close()
 {
+    // 先失效 session — VT 保证后续不再触发回调
     if (d->session) { VTDecompressionSessionInvalidate(d->session); CFRelease(d->session); d->session = nullptr; }
     if (d->formatDesc) { CFRelease(d->formatDesc); d->formatDesc = nullptr; }
+
+    // dispatch_semaphore 的 release 必须在 VT session 失效后短暂延迟，
+    // 确保任何仍在执行的 callback 已完成 signal。
+    // VTDecompressionSessionInvalidate 是同步的，所以此处的 signal 安全。
     if (d->semaphore) { dispatch_release(d->semaphore); d->semaphore = nullptr; }
+
     if (d->outputPixelBuffer) { CVPixelBufferRelease(d->outputPixelBuffer); d->outputPixelBuffer = nullptr; }
     d->cachedSPS.clear();
     d->cachedPPS.clear();

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -25,8 +25,11 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
 
     if (params.display) {
         // 根据 decodeMode 工厂创建解码器
+        bool useVT = false;
 #ifdef Q_OS_MACOS
-        if (m_params.decodeMode == MODE_VT_METAL && VTDecoder::isAvailable()) {
+        useVT = (m_params.decodeMode == MODE_VT_METAL && VTDecoder::isAvailable());
+#endif
+        if (useVT) {
             auto* vt = new VTDecoder(this);
             vt->onFrame = [this](void* cvPixelBuffer, int width, int height) {
                 for (const auto& item : m_deviceObservers) {
@@ -34,9 +37,7 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
                 }
             };
             m_decoder = vt;
-        } else
-#endif
-        {
+        } else {
             m_decoder = new Decoder([this](int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV) {
                 for (const auto& item : m_deviceObservers) {
                     item->onFrame(width, height, dataY, dataU, dataV, linesizeY, linesizeU, linesizeV);

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -26,6 +26,14 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
                 item->onFrame(width, height, dataY, dataU, dataV, linesizeY, linesizeU, linesizeV);
             }
         }, this);
+
+        // VT Metal 路径帧回调（仅 macOS arm64 生效）
+        m_decoder->onMetalFrame = [this](void* cvPixelBuffer, int width, int height) {
+            for (const auto& item : m_deviceObservers) {
+                item->onFrameMetal(cvPixelBuffer, width, height);
+            }
+        };
+
         m_fileHandler = new FileHandler(this);
         m_controller = new Controller([this](const QByteArray& buffer) -> qint64 {
             if (!m_server || !m_server->getControlSocket()) {
@@ -189,7 +197,7 @@ void Device::initSignals()
 
                 // init decoder
                 if (m_decoder) {
-                    m_decoder->open();
+                    m_decoder->open(m_params.decodeMode);
                 }
 
                 // init stream

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -5,6 +5,9 @@
 #include "controller.h"
 #include "devicemsg.h"
 #include "decoder.h"
+#ifdef Q_OS_MACOS
+#include "vtdecoder.h"
+#endif
 #include "device.h"
 #include "filehandler.h"
 #include "recorder.h"
@@ -21,18 +24,25 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
     }
 
     if (params.display) {
-        m_decoder = new Decoder([this](int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV) {
-            for (const auto& item : m_deviceObservers) {
-                item->onFrame(width, height, dataY, dataU, dataV, linesizeY, linesizeU, linesizeV);
-            }
-        }, this);
-
-        // VT Metal 路径帧回调（仅 macOS arm64 生效）
-        m_decoder->onMetalFrame = [this](void* cvPixelBuffer, int width, int height) {
-            for (const auto& item : m_deviceObservers) {
-                item->onFrameMetal(cvPixelBuffer, width, height);
-            }
-        };
+        // 根据 decodeMode 工厂创建解码器
+#ifdef Q_OS_MACOS
+        if (m_params.decodeMode == MODE_VT_METAL && VTDecoder::isAvailable()) {
+            auto* vt = new VTDecoder(this);
+            vt->onFrame = [this](void* cvPixelBuffer, int width, int height) {
+                for (const auto& item : m_deviceObservers) {
+                    item->onFrameMetal(cvPixelBuffer, width, height);
+                }
+            };
+            m_decoder = vt;
+        } else
+#endif
+        {
+            m_decoder = new Decoder([this](int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV) {
+                for (const auto& item : m_deviceObservers) {
+                    item->onFrame(width, height, dataY, dataU, dataV, linesizeY, linesizeU, linesizeV);
+                }
+            }, this);
+        }
 
         m_fileHandler = new FileHandler(this);
         m_controller = new Controller([this](const QByteArray& buffer) -> qint64 {
@@ -197,7 +207,7 @@ void Device::initSignals()
 
                 // init decoder
                 if (m_decoder) {
-                    m_decoder->open(m_params.decodeMode);
+                    m_decoder->open();
                 }
 
                 // init stream
@@ -260,7 +270,7 @@ void Device::initSignals()
     }
 
     if (m_decoder) {
-        connect(m_decoder, &Decoder::updateFPS, this, [this](quint32 fps) {
+        connect(m_decoder, &IDecoder::updateFPS, this, [this](quint32 fps) {
             for (const auto& item : m_deviceObservers) {
                 item->updateFPS(fps);
             }

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -14,7 +14,7 @@ class QKeyEvent;
 class Recorder;
 class Server;
 class VideoBuffer;
-class Decoder;
+class IDecoder;
 class FileHandler;
 class Demuxer;
 class VideoForm;
@@ -81,7 +81,7 @@ private:
     // server relevant
     QPointer<Server> m_server;
     bool m_serverStartSuccess = false;
-    QPointer<Decoder> m_decoder;
+    QPointer<IDecoder> m_decoder;
     QPointer<Controller> m_controller;
     QPointer<FileHandler> m_fileHandler;
     QPointer<Demuxer> m_stream;


### PR DESCRIPTION
## Summary

While using QtScrcpy on my M1 Pro MacBook to play Android mobile games, I noticed the laptop's CPU usage was consistently at **50–80%**. Profiling showed nearly all of it came from FFmpeg's single-threaded H.264 software decoder. Apple Silicon Macs have a dedicated Media Engine hardware block — this PR adds a `VTDecoder` that uses it via the VideoToolbox framework, plus extends `Decoder` to support choosing between software and hardware decode at runtime.

## The problem

The existing `Decoder` always uses `avcodec_find_decoder(AV_CODEC_ID_H264)` with software-only FFmpeg (compiled with `--disable-everything`). At 1080×2456 resolution, this single-threaded decode path consumes ~50% CPU. The decoded YUV420P frames then go through OpenGL texture upload on Apple's GL→Metal translation layer, adding overhead.

Apple Silicon's Media Engine can do H.264 hardware decode with **no CPU involvement** — the output lands directly in an IOSurface-backed CVPixelBuffer in GPU memory. We just need to feed it the bitstream in the format it expects.

## The solution

`VTDecoder` wraps the full VideoToolbox decode pipeline in ~350 lines:

- **Annex B → AVCC conversion**: FFmpeg's parser outputs Annex B (`00 00 01` start codes). VTDecompressionSession expects AVCC (4-byte length prefixes). The converter scans NAL units with a stack-allocated array — no per-frame heap allocation.
- **Lazy session creation**: On the first frame containing SPS/PPS, a `CMVideoFormatDescription` is created, then a `VTDecompressionSession` configured for NV12 output with Metal compatibility and IOSurface backing.
- **Resolution change detection**: SPS/PPS raw bytes are cached. When a new SPS arrives (e.g. device rotation), `memcmp` detects the change, invalidates the old session, and creates a new one with the updated format description.
- **Async-to-sync bridging**: `VTDecompressionSessionDecodeFrame()` is asynchronous. A `dispatch_semaphore` with 500ms timeout waits for the callback, making the interface synchronous for the caller.
- **Zero-copy memory**: `CMBlockBufferCreateWithMemoryBlock` uses `kCFAllocatorMalloc` — CoreMedia takes ownership and calls `free()` when done.

`Decoder` gains a dual-mode architecture:

- `DecodeMode` enum: `MODE_FFMPEG` (0, default) and `MODE_VT_METAL` (1)
- `open(decodeMode)` selects the path at runtime
- `pushVT()` routes AVPackets to VTDecoder and manages CVPixelBuffer lifecycle
- `onNewFrame()` with `QMutexLocker` ensures the pixel buffer stays valid across the demuxer→main thread boundary
- `peekFrame()` handles NV12→RGB conversion for screenshots via direct CVPixelBuffer access
- `onMetalFrame` callback chain: Decoder → Device → VideoForm → MetalVideoWidget

## New files
- `src/device/decoder/vtdecoder.h` — C++ interface
- `src/device/decoder/vtdecoder.mm` — ObjC++ implementation (see above)

## Modified files
- `src/device/decoder/decoder.h` / `.cpp` — dual-mode support, QMutex, pixel buffer lifecycle
- `src/device/device.cpp` — wire `onMetalFrame` to `DeviceObserver::onFrameMetal()`
- `include/QtScrcpyCore.h` — `DeviceObserver::onFrameMetal(void*, int, int)` virtual method
- `include/QtScrcpyCoreDef.h` — `DeviceParams::decodeMode` field (default 0)
- `CMakeLists.txt` — macOS-only: `vtdecoder.mm`, VideoToolbox/CoreMedia/CoreVideo frameworks

## Verification

Test environment: macOS 14, M1 Pro, Qt 6.7.3, Xiaomi Redmi 23054RA19C (Android 13), 1080×2456, WiFi.

| Metric | FFmpeg (before) | VT Metal (after) |
|---|---|---|
| H.264 decode | ~50% CPU | ~0% CPU (Media Engine) |
| Frame pipeline | YUV420P, CPU→GPU copy | NV12, IOSurface zero-copy |
| Rotation handling | Auto (FFmpeg) | SPS/PPS change detection with session rebuild |

This is my first contribution to this repo — feedback welcome!
