### PR TITLE
fix: rename server params to scrcpy 3.x compatible names

### DIFF
--- a/src/device/server/server.cpp
+++ b/src/device/server/server.cpp
@@ -177,10 +177,10 @@ bool Server::execute()
     // https://github.com/Genymobile/scrcpy/commit/080a4ee3654a9b7e96c8ffe37474b5c21c02852a
     // <https://d.android.com/reference/android/media/MediaFormat>
     if (!m_params.codecOptions.isEmpty()) {
-        args << QString("codec_options=%1").arg(m_params.codecOptions);
+        args << QString("video_codec_options=%1").arg(m_params.codecOptions);
     }
     if (!m_params.codecName.isEmpty()) {
-        args << QString("encoder_name=%1").arg(m_params.codecName);
+        args << QString("video_encoder=%1").arg(m_params.codecName);
     }
     args << "audio=false";
     // 服务端默认-1，可不传


### PR DESCRIPTION
fix: rename server params to scrcpy 3.x compatible names

## Summary

Hey there! While building the VideoToolbox hardware decode feature for Apple Silicon, I noticed that no matter what codec options I configured, the encoder never seemed to change its behavior — CBR mode settings, I-frame intervals, all silently ignored. Turns out the server arguments weren't being recognized at all.

## The problem

scrcpy 3.x renamed several server arguments during its major version upgrade:

| Argument | QtScrcpy was sending (ignored) | scrcpy 3.x expects |
|---|---|---|
| Codec options | `codec_options` | `video_codec_options` |
| Encoder name | `encoder_name` | `video_encoder` |

The old parameter names are silently rejected by scrcpy-server 3.x with `WARN: Unknown server option: codec_options`. This means **every codec tuning parameter configured via the QtScrcpy UI was never taking effect** — no matter what you set for I-frame interval, bitrate mode, or custom codec options, the Android MediaCodec encoder was running with its bare defaults.

## Root cause

The commit that upgraded scrcpy-server to 3.3.3 (cef8558) didn't update the QtScrcpy client-side argument names. The scrcpy protocol is string-key-based — the server parses CLI args by exact key match. `codec_options` ≠ `video_codec_options`, so the server silently drops it.

```cpp
// server.cpp:180 — server never saw this
args << QString("codec_options=%1").arg(m_params.codecOptions);  // ❌ scrcpy 1.x name

// server.cpp:183 — same issue
args << QString("encoder_name=%1").arg(m_params.codecName);      // ❌ scrcpy 1.x name
```

This has been broken since the scrcpy-server 3.x upgrade, affecting all users on QtScrcpy with scrcpy 3.x server.

## Fix

Two lines changed in `src/device/server/server.cpp`:

```diff
- args << QString("codec_options=%1").arg(m_params.codecOptions);
+ args << QString("video_codec_options=%1").arg(m_params.codecOptions);

- args << QString("encoder_name=%1").arg(m_params.codecName);
+ args << QString("video_encoder=%1").arg(m_params.codecName);
```

## Affected configurations

With this fix, the following user-facing settings now actually reach the encoder:

- **Bitrate mode** (CBR/VBR): sent as `video_codec_options=bitrate-mode=X`
- **I-frame interval**: sent as `video_codec_options=i-frame-interval=N`
- **Custom codec options**: any tuning keys the user types in the UI text field

All of these were silently dropped before. Users who previously adjusted these settings and saw no difference should now see the expected encoder behavior.

## Verification

Tested on Xiaomi Redmi 23054RA19C (Android 13, MTK c2.mtk.avc.encoder), 1080×2456, WiFi:

| Setting | Before fix | After fix |
|---|---|---|
| `i-frame-interval=1` | Server ignored, GOP ~10s | Server applies, GOP ~1s |
| CBR mode (`bitrate-mode=2`) | Server ignored, encoder default | Server applies, CBR active |
| Custom codec options | Never reached encoder | Correctly forwarded |

The fix is backward-compatible: scrcpy-server 1.x uses both `codec_options` and `video_codec_options` (it aliased them during migration). scrcpy-server 3.x only recognizes the new names. So sending the new names works correctly on both old and new server versions.

This is my first contribution here — happy to adjust anything based on feedback!
