### PR TITLE
fix: guard VTDecoder usage with Q_OS_MACOS preprocessor check

### DIFF
--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -30,6 +30,7 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
         useVT = (m_params.decodeMode == MODE_VT_METAL && VTDecoder::isAvailable());
 #endif
         if (useVT) {
+#ifdef Q_OS_MACOS
             auto* vt = new VTDecoder(this);
             vt->onFrame = [this](void* cvPixelBuffer, int width, int height) {
                 for (const auto& item : m_deviceObservers) {
@@ -37,6 +38,7 @@ Device::Device(DeviceParams params, QObject *parent) : IDevice(parent), m_params
                 }
             };
             m_decoder = vt;
+#endif
         } else {
             m_decoder = new Decoder([this](int width, int height, uint8_t* dataY, uint8_t* dataU, uint8_t* dataV, int linesizeY, int linesizeU, int linesizeV) {
                 for (const auto& item : m_deviceObservers) {


### PR DESCRIPTION
## Problem

`device.cpp` references `VTDecoder` without a preprocessor guard on non-macOS platforms. Since `VTDecoder` is declared in `vtdecoder.h` only included under `Q_OS_MACOS`, GCC/MSVC fail with:

device.cpp:33:28: error: expected type-specifier before 'VTDecoder'

This blocks Linux and Windows builds when the parent project (QtScrcpy) pulls this change into its VideoToolbox feature branch.

## Fix

Wrap the `VTDecoder` instantiation block with `#ifdef Q_OS_MACOS` / `#endif`:

```cpp
if (useVT) {
#ifdef Q_OS_MACOS       // ← added
    auto* vt = new VTDecoder(this);
    ...
    m_decoder = vt;
#endif                  // ← added
} else {
```

On non-macOS, `useVT` is already `false` at runtime, so the block is never entered — the `#ifdef` purely removes the type reference from the translation unit.

## Verification

- macOS: `VTDecoder` is included and instantiated normally (no behavior change)
- Linux: GCC no longer sees `VTDecoder` symbol → compiles successfully
- Windows: MSVC no longer sees `VTDecoder` symbol → compiles successfully