### PR TITLE
fix: exclude vtdecoder.h from non-macOS source lists to prevent AUTOMOC linker errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ set(QSC_DEVICE_SOURCES
     src/device/decoder/fpscounter.cpp
     src/device/decoder/videobuffer.h
     src/device/decoder/videobuffer.cpp
-    src/device/decoder/vtdecoder.h
     src/device/filehandler/filehandler.h
     src/device/filehandler/filehandler.cpp
     src/device/recorder/recorder.h
@@ -203,6 +202,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # VideoToolbox decoder (macOS, Objective-C++)
     target_sources(${QSC_PROJECT_NAME} PRIVATE
         src/device/decoder/vtdecoder.mm
+        src/device/decoder/vtdecoder.h
     )
 
     # ffmpeg


### PR DESCRIPTION
### Problem

After the previous PR (which added `#ifdef` guards in `device.cpp`) was merged, Ubuntu and Windows CI still fail at the link stage:

```
undefined reference to `VTDecoder::onNewFrame()'
undefined reference to `VTDecoder::~VTDecoder()'
undefined reference to `VTDecoder::open()'
undefined reference to `VTDecoder::close()'
undefined reference to `VTDecoder::push(AVPacket const*)'
```

### Root Cause

`vtdecoder.h` contains the `Q_OBJECT` macro. CMake's `AUTOMOC` processes this header on **all platforms**, generating `moc_vtdecoder.cpp` (signal/slot/meta-object code). However, `vtdecoder.mm` is only compiled on Darwin, so Linux/Windows linkers cannot find the VTDecoder method implementations, resulting in `undefined reference` errors.

### Fix

Move `vtdecoder.h` from the unconditional `QSC_DEVICE_SOURCES` list into the Darwin-only `target_sources` block:

```diff
-    src/device/decoder/vtdecoder.h   # all platforms

     # Darwin only
+    src/device/decoder/vtdecoder.h   # alongside vtdecoder.mm
     src/device/decoder/vtdecoder.mm
```

This ensures AUTOMOC only processes the header on macOS; non-macOS platforms are unaffected.

### Verification

- macOS arm64: builds normally, VideoToolbox/Metal functionality unaffected
- Linux/Windows: no more VTDecoder-related linker errors

### Related

- Previous PR: `fix: guard VTDecoder usage with Q_OS_MACOS ifdef` (fixed `device.cpp` compile errors)
- This PR fixes the remaining issue from the same feature: AUTOMOC linker errors caused by incorrect source file attribution in `CMakeLists.txt`